### PR TITLE
Add a config file for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+# Choose the supported versions of python.
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+# Use miniconda to install the python scientific stack.
+# This proved to be easier and faster than faster than using pip
+before_install:
+  - |
+   wget \
+     http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+     -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b -p $(pwd)/miniconda
+  - export PATH=$(pwd)/miniconda/bin:$PATH
+  - conda update --yes conda
+# Provide a X display for plotting
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+# Install the dependencies
+# We explicitely install the python scientific stack using conda. Lighter
+# dependencies can be installed automatically with pip.
+install:
+  - | 
+    conda create \
+      --yes -q -n pyenv \
+      python=$TRAVIS_PYTHON_VERSION \
+      numpy scipy sympy matplotlib seaborn nose
+  - source activate pyenv
+  - pip install .
+# Run tests
+script: nosetests


### PR DESCRIPTION
This PR allows to activate continuous integration using Travis-CI, see #73. To activate Travis, and once the file is merged, it is still needed for @tBuLi to create an account on Travis and to turn the continuous integration for the symfit repository.

The `.travis.yml` file gives the build instruction to Travis. It installs the dependencies using conda, and run the tests using nose.

At the moment, the tests fail. But they fails in the same way on my computer.

The results of the test can be seen on https://travis-ci.org/jbarnoud/symfit