### PR TITLE
Fixed an issue with the dimensionaly of the Dfun argument to odeint

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -2186,8 +2186,10 @@ class ODEModel(CallableModel):
     @property
     @cache
     def _njacobian(self):
-        return [sympy_to_py(sympy.diff(expr, var), self.independent_vars + self.dependent_vars, self.params) for var, expr in self.items()]
-        # return [sympy_to_py(sympy.diff(expr, var), self.independent_vars + self.dependent_vars, self.params) for var, expr in self.items()]
+        return [
+            [sympy_to_py(sympy.diff(expr, var), self.independent_vars + self.dependent_vars, self.params) for var in self.dependent_vars]
+            for _, expr in self.items()
+        ]
 
     def eval_components(self, *args, **kwargs):
         """
@@ -2204,7 +2206,7 @@ class ODEModel(CallableModel):
 
         # System of functions to be integrated
         f = lambda ys, t, *a: [c(t, *(list(ys) + list(a))) for c in self._ncomponents]
-        Dfun = lambda ys, t, *a: [c(t, *(list(ys) + list(a))) for c in self._njacobian]
+        Dfun = lambda ys, t, *a: [[c(t, *(list(ys) + list(a))) for c in row] for row in self._njacobian]
 
         initial_dependent = [self.initial[var] for var in self.dependent_vars]
         initial_independent = self.initial[self.independent_vars[0]] # Assuming there's only one


### PR DESCRIPTION
In checking interactive_guess I found that it's example with 2D ODE's didn't work. It's weird that similar examples in the tests did run properly, but the jacobian was indeed a vector and not a matrix as it should be.

This branch fixes this, and I will also use this later to implement `numerical_jacobian` on ODEModels later.