### PR TITLE
Fit results cleanup

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -104,9 +104,8 @@ fit result::
 
   y = model(x=xdata, **fit_result.params)
   
-This unpacks the :attr:`~symfit.core.fit.FitResults.params` object as a
-:class:`dict`. For more info view :class:`~symfit.core.fit.ParameterDict` in
-the :ref:`apidocs`.
+This immediately unpacks an :class:`~collections.OrderedDict` containing the optimized fit
+parameters.
 
 Named Models
 ------------

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -1377,7 +1377,7 @@ class Minimize(BaseFit):
         # s_sq = (infodic['fvec'] ** 2).sum() / (len(self.ydata) - len(popt))
         # pcov = cov_x * s_sq if cov_x is not None else None
 
-        self.__fit_results = FitResults(
+        self._fit_results = FitResults(
             params=self.model.params,
             popt=ans.x,
             pcov=None,
@@ -1386,10 +1386,10 @@ class Minimize(BaseFit):
             ier=ans.nit,
         )
         try:
-            self.__fit_results.r_squared = r_squared(self.model, self.__fit_results, self.data)
+            self._fit_results.r_squared = r_squared(self.model, self._fit_results, self.data)
         except ValueError:
-            self.__fit_results.r_squared = float('nan')
-        return self.__fit_results
+            self._fit_results.r_squared = float('nan')
+        return self._fit_results
 
     @property
     def scipy_constraints(self):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -151,19 +151,16 @@ class FitResults(object):
     Class to display the results of a fit in a nice and unambiguous way.
     All things related to the fit are available on this class, e.g.
     - parameters + stdev
-    - R squared (Regression coefficient.)
+    - R squared (Regression coefficient.) or other fit quality qualifiers.
     - fitting status message
-
-    This object is made to behave entirely read-only. This is a bit unnatural
-    to enforce in Python but I feel it is necessary to guarantee the integrity
-    of the results.
+    - covariance matrix
     """
-    __params = None  # Private property.
-    __infodict = None
-    __status_message = None
-    __iterations = None
-    __ydata = None
-    __sigma = None
+    # __params = None  # Private property.
+    # __infodict = None
+    # __status_message = None
+    # __iterations = None
+    # __ydata = None
+    # __sigma = None
 
     def __init__(self, params, popt, pcov, infodic, mesg, ier, ydata=None, sigma=None):
         """
@@ -178,12 +175,12 @@ class FitResults(object):
         :param ydata:
         """
         # Validate the types in rough way
-        self.__infodict = infodic
-        self.__status_message = mesg
-        self.__iterations = ier
-        self.__ydata = ydata
-        self.__params = ParameterDict(params, popt, pcov)
-        self.__sigma = sigma
+        self._infodict = infodic
+        self._status_message = mesg
+        self._iterations = ier
+        self._ydata = ydata
+        self._params = ParameterDict(params, popt, pcov)
+        self._sigma = sigma
 
     def __str__(self):
         """
@@ -230,28 +227,28 @@ class FitResults(object):
         """
         Read-only Property.
         """
-        return self.__infodict
+        return self._infodict
 
     @property
     def status_message(self):
         """
         Read-only Property.
         """
-        return self.__status_message
+        return self._status_message
 
     @property
     def iterations(self):
         """
         Read-only Property.
         """
-        return self.__iterations
+        return self._iterations
 
     @property
     def params(self):
         """
         Read-only Property.
         """
-        return self.__params
+        return self._params
 
     def stdev(self, param):
         """

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -1678,8 +1678,7 @@ class ConstrainedNumericalLeastSquares(Minimize, HasCovarianceMatrix):
         description.
         """
         fit_result = super(ConstrainedNumericalLeastSquares, self).execute(*args, **kwargs)
-        # Extract the best fit parameters. Replace by fit_result.params.values() if #45 is fixed.
-        popt = [fit_result.value(p) for p in self.model.params]
+        popt = fit_result.params.values()
 
         try:
             cov_matrix = self.covariance_matrix(fit_result.params)

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -35,6 +35,11 @@ class FitResults(object):
     - R squared (Regression coefficient.) or other fit quality qualifiers.
     - fitting status message
     - covariance matrix
+
+    Contains the attribute `params`, which is an
+    :class:`~collections.OrderedDict` containing all the parameter names and
+    their optimized values. Can be `**` unpacked when evaluating
+    :class:`~symfit.core.fit.Model`'s.
     """
     def __init__(self, model, popt, pcov, infodic, mesg, ier, **gof_qualifiers):
         """

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -175,11 +175,11 @@ class FitResults(object):
         :param ydata:
         """
         # Validate the types in rough way
-        self._infodict = infodic
-        self._status_message = mesg
-        self._iterations = ier
+        self.infodict = infodic
+        self.status_message = mesg
+        self.iterations = ier
         self._ydata = ydata
-        self._params = ParameterDict(params, popt, pcov)
+        self.params = ParameterDict(params, popt, pcov)
         self._sigma = sigma
 
     def __str__(self):
@@ -214,41 +214,6 @@ class FitResults(object):
     @r_squared.setter
     def r_squared(self, value):
         self._r_squared = value
-
-    #
-    # READ-ONLY Properties
-    # What follows are all the read-only properties of this object.
-    # Their definitions are mostly trivial, but necessary to make sure that
-    # FitResults can't be changed.
-    #
-
-    @property
-    def infodict(self):
-        """
-        Read-only Property.
-        """
-        return self._infodict
-
-    @property
-    def status_message(self):
-        """
-        Read-only Property.
-        """
-        return self._status_message
-
-    @property
-    def iterations(self):
-        """
-        Read-only Property.
-        """
-        return self._iterations
-
-    @property
-    def params(self):
-        """
-        Read-only Property.
-        """
-        return self._params
 
     def stdev(self, param):
         """

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -57,7 +57,10 @@ class FitResults(object):
         self.gof_qualifiers = gof_qualifiers
 
         self.params = OrderedDict([(p.name, value) for p, value in zip(self.model.params, popt)])
+        if pcov is None:
+            pcov = np.array([[None for _ in range(len(self.params))] for _ in range(len(self.params))])
         self.covariance_matrix = pcov
+
 
     def __str__(self):
         """
@@ -94,7 +97,11 @@ class FitResults(object):
         :param param: ``Parameter`` Instance.
         :return: Standard deviation of ``param``.
         """
-        return np.sqrt(self.variance(param))
+        try:
+            return np.sqrt(self.variance(param))
+        except AttributeError:
+            # This happens when variance returns None.
+            return None
 
     def value(self, param):
         """

--- a/tests/test_analytical_fit.py
+++ b/tests/test_analytical_fit.py
@@ -118,7 +118,7 @@ class TestAnalyticalFit(unittest.TestCase):
         self.assertAlmostEqual(var_b_exact, fit_result.variance(b), 6)
 
         # Lets also make sure the entire covariance matrix is the same
-        for cov1, cov2 in zip(fit_result.params.covariance_matrix.flatten(), pcov.flatten()):
+        for cov1, cov2 in zip(fit_result.covariance_matrix.flatten(), pcov.flatten()):
             self.assertAlmostEqual(cov1, cov2)
 
     def test_is_linear(self):
@@ -174,7 +174,7 @@ class TestAnalyticalFit(unittest.TestCase):
         num_result = fit.execute()
 
         # cov matrix should now be different
-        for cov1, cov2 in zip(num_result_rel.params.covariance_matrix.flatten(), num_result.params.covariance_matrix.flatten()):
+        for cov1, cov2 in zip(num_result_rel.covariance_matrix.flatten(), num_result.covariance_matrix.flatten()):
             # Make the absolute cov relative to see if it worked.
             ss_res = np.sum(num_result_rel.infodict['fvec']**2)
             degrees_of_freedom = len(fit.data[fit.model.dependent_vars[0].name]) - len(fit.model.params)
@@ -192,7 +192,7 @@ class TestAnalyticalFit(unittest.TestCase):
         #     self.assertAlmostEqual(cov1, cov2)
         #     print(cov1, cov2)
 
-        for cov1, cov2 in zip(num_result.params.covariance_matrix.flatten(), fit_result.params.covariance_matrix.flatten()):
+        for cov1, cov2 in zip(num_result.covariance_matrix.flatten(), fit_result.covariance_matrix.flatten()):
             self.assertAlmostEqual(cov1, cov2)
             # print(cov1, cov2)
 
@@ -275,7 +275,7 @@ class TestAnalyticalFit(unittest.TestCase):
 
         self.assertAlmostEqual(num_result.value(g), fit_result.value(g))
 
-        for cov1, cov2 in zip(num_result.params.covariance_matrix.flatten(), fit_result.params.covariance_matrix.flatten()):
+        for cov1, cov2 in zip(num_result.covariance_matrix.flatten(), fit_result.covariance_matrix.flatten()):
             self.assertAlmostEqual(cov1, cov2)
 
     def test_2D_fitting(self):

--- a/tests/test_auto_fit.py
+++ b/tests/test_auto_fit.py
@@ -92,9 +92,9 @@ class TestAutoFit(unittest.TestCase):
         self.assertIsInstance(bound_fit.fit, ConstrainedNumericalLeastSquares)
 
         fit_result = bound_fit.execute()
-        self.assertAlmostEqual(fit_result.params.a, np.mean(xdata[0]), 6)
-        self.assertAlmostEqual(fit_result.params.b, np.mean(xdata[1]), 6)
-        self.assertAlmostEqual(fit_result.params.c, np.mean(xdata[2]), 6)
+        self.assertAlmostEqual(fit_result.value(a), np.mean(xdata[0]), 6)
+        self.assertAlmostEqual(fit_result.value(b), np.mean(xdata[1]), 6)
+        self.assertAlmostEqual(fit_result.value(c), np.mean(xdata[2]), 6)
 
     def test_vector_fitting_bounds(self):
         """

--- a/tests/test_fit_result.py
+++ b/tests/test_fit_result.py
@@ -3,6 +3,7 @@ import unittest
 import warnings
 import sympy
 import types
+from collections import OrderedDict
 
 import numpy as np
 from symfit import Variable, Parameter, Fit, FitResults, NumericalLeastSquares, Model
@@ -31,8 +32,10 @@ class TestFitResults(unittest.TestCase):
         # raise Exception(fit.model.chi_jacobian)
         fit_result = fit.execute()
 
+        self.assertTrue(isinstance(fit_result.params, OrderedDict))
         # Should no longer be read-only, so setable. Should not raise an error
         fit_result.params = 'hello'
+        self.assertTrue(isinstance(fit_result.params, str))
 
     def test_fitting(self):
         xdata = np.linspace(1,10,10)
@@ -111,27 +114,13 @@ class TestFitResults(unittest.TestCase):
         fit = Fit(model, xx, yy, ydata)
         fit_result = fit.execute()
 
-        for param in fit_result.params:
+        for param in fit.model.params:
             self.assertAlmostEqual(fit_result.stdev(param)**2, fit_result.variance(param))
-            self.assertEqual(fit_result.stdev(param), fit_result.params.stdev(param))
-            self.assertEqual(fit_result.value(param), fit_result.params.value(param))
 
         # Covariance matrix should be symmetric
-        for param_1 in fit_result.params:
-            for param_2 in fit_result.params:
+        for param_1 in fit.model.params:
+            for param_2 in fit.model.params:
                 self.assertAlmostEqual(fit_result.covariance(param_1, param_2), fit_result.covariance(param_2, param_1))
-#        print(fit_result.params.covariance_matrix)
-#        print(fit_result.covariance(x0_1, x0_2))
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger DeprecationWarning
-            fit_result.params.get_stdev(x0_1)
-            fit_result.params.get_value(x0_1)
-            self.assertTrue(len(w) == 2)
-            for warning in w:
-                self.assertTrue(issubclass(warning.category, DeprecationWarning))
 
 
 if __name__ == '__main__':

--- a/tests/test_fit_result.py
+++ b/tests/test_fit_result.py
@@ -13,6 +13,7 @@ class TestFitResults(unittest.TestCase):
     """
     Tests for the FitResults object.
     """
+
     def test_read_only_results(self):
         """
         Fit results should be read-only. Let's try to break this!
@@ -30,53 +31,9 @@ class TestFitResults(unittest.TestCase):
         # raise Exception(fit.model.chi_jacobian)
         fit_result = fit.execute()
 
-        # Break it!
-        try:
+        # Should be read-only, so unsetable.
+        with self.assertRaises(AttributeError):
             fit_result.params = 'hello'
-        except AttributeError:
-            self.assertTrue(True) # desired result
-        finally:
-            self.assertNotEqual(fit_result.params, 'hello')
-
-        try:
-            # Bypass the property getter. This will work, as it set's the instance value of __params.
-            fit_result.__params = 'hello'
-        except AttributeError:
-            self.assertTrue(False) # undesired result
-        finally:
-            self.assertNotEqual(fit_result.params, 'hello')
-            # The assginment will have succeeded on the instance because we set it from the outside.
-            # I must admit I don't fully understand why this is allowed and I don't like it.
-            # However, the tests below show that it did not influence the class method itself so
-            # fitting still works fine.
-            # assinging to __params makes *new* instance attribute, the "real"
-            # __params instance is called _FitResult__params. See dir(fit_results) and
-            # https://www.python.org/dev/peps/pep-0008/#designing-for-inheritance
-            self.assertEqual(fit_result.__params, 'hello')
-
-        # Do a second fit and dubble check that we do not overwrtie something crusial.
-        xdata = np.arange(-5, 5, 1)
-        ydata = np.arange(-5, 5, 1)
-        xx, yy = np.meshgrid(xdata, ydata, sparse=False)
-        xdata_coor = np.dstack((xx, yy))
-
-        zdata = 2.5*xx**2 + 3.0*yy**2
-
-        a = Parameter(1., max=2.75)
-        b = Parameter(5., min=2.75)
-        x = Variable()
-        y = Variable()
-        new = Variable()
-        new_model = Model({new: a*x**2 + b*y**2 })
-
-        fit_2 = Fit(new_model, x=xx, y=yy, new=zdata)
-        fit_result_2 = fit_2.execute()
-        self.assertNotAlmostEqual(fit_result.value(a), fit_result_2.value(a))
-        self.assertAlmostEqual(fit_result.value(a), 3.0)
-        self.assertAlmostEqual(fit_result_2.value(a), 2.5)
-        self.assertNotAlmostEqual(fit_result.value(b), fit_result_2.value(b))
-        self.assertAlmostEqual(fit_result.value(b), 2.0)
-        self.assertAlmostEqual(fit_result_2.value(b), 3.0)
 
     def test_fitting(self):
         xdata = np.linspace(1,10,10)

--- a/tests/test_fit_result.py
+++ b/tests/test_fit_result.py
@@ -31,9 +31,8 @@ class TestFitResults(unittest.TestCase):
         # raise Exception(fit.model.chi_jacobian)
         fit_result = fit.execute()
 
-        # Should be read-only, so unsetable.
-        with self.assertRaises(AttributeError):
-            fit_result.params = 'hello'
+        # Should no longer be read-only, so setable. Should not raise an error
+        fit_result.params = 'hello'
 
     def test_fitting(self):
         xdata = np.linspace(1,10,10)


### PR DESCRIPTION
This PR aims to solve #57, #45, #91.

It makes a rethink of the ``**fit_result.params`` syntax necessary, to prevent confusion with ``Model.params`` which is entirely different. (The first should be an `OrderedDict` with the optimized parameters, second a list of `Parameter` objects.)

Options are ``**fit_result`` or a renaming of the dict to e.g. ``**fit_results.fit_params``.

Because this will be a significant API change in either case, a good rethink is needed.

I am against the first option for the same reasons I did not originally do this: if you iterate over a FitResults object, what do you expect to iterate over? I can only see two options: it's entire contents, or different solutions to the fitting problem (local minima). But not just the fit parameters. Additionally, making a custom mapping object adds complications over just using the build-in ones (I learned that the hard way, see #57).

So my preferred solution is definitely to just give ``fit_result.params`` a different name, and have it be an `OrderedDict`. 

Suggestions are welcome.