### PR TITLE
Switched back to last known working sphynx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   # Upgrade pip to enable the --only-binary flag; setuptools for pbr.
   - pip install --upgrade pip setuptools
   - pip install --upgrade pytest
-  - pip install --upgrade sphinx
+  - pip install --upgrade sphinx==1.5.5
   - pip install --only-binary numpy,scipy,matplotlib .[all]
   - echo $PATH
 # Run tests


### PR DESCRIPTION
My suspicion is that the recent failing of builds is because the latest version of sphynx and pbr do not play nice.