### PR TITLE
Constraint object work with all models now

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -729,7 +729,7 @@ class Constraint(Model):
         # raise Exception(model)
         if isinstance(constraint, Relational):
             self.constraint_type = type(constraint)
-            if isinstance(model, Model):
+            if isinstance(model, BaseModel):
                 self.model = model
             else:
                 raise TypeError('The model argument must be of type Model.')


### PR DESCRIPTION
Apparently constraints didn't work with ODEModel, only with Model. Updated this to allow all children of BaseModel to the party.