### PR TITLE
Remove inspect, more sympy compatible style.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ http://symfit.readthedocs.org
 Project Goals
 =============
 
-The goal of this project is simple: to make fitting in Python sexy and pythonic.
+The goal of this project is simple: to make fitting in Python pythonic.
 What does pythonic fitting look like? Well, there's a simple test. If I can
 give you pieces of example code and don't have to use any additional words to
 explain what it does, it's pythonic.
@@ -34,8 +34,8 @@ Cool right? So now that we have done a fit, how do we use the results?
 
   import matplotlib.pyplot as plt
   
-  y = model(x=xdata, **fit_result.params)
-  plt.plot(xdata, y)
+  yfit = model(x=xdata, **fit_result.params)[y]
+  plt.plot(xdata, yfit)
   plt.show()
 
 .. figure:: http://symfit.readthedocs.org/en/latest/_images/linear_model_fit.png
@@ -68,7 +68,7 @@ I know what you are thinking. "What if I need to fit to a system of Ordinary Dif
   adata = 10e-4 * np.array([44, 34, 27, 20, 14])
           
   a, b, t = variables('a, b, t')
-  k = Parameter(0.1)
+  k = Parameter('k', 0.1)
   
   model_dict = {
       D(a, t): - k * a**2,

--- a/docs/api_structure.rst
+++ b/docs/api_structure.rst
@@ -57,9 +57,9 @@ Let's say we have some data::
 
 And we want to fit it to some model::
 
-    a = Parameter(value=0, min=0, max=1000)
-    b = Parameter(value=0, min=0, max=1000)
-    x = Variable()
+    a = Parameter('a', value=0, min=0, max=1000)
+    b = Parameter('b', value=0, min=0, max=1000)
+    x = Variable('x')
     model = a * x + b
 
 If we want to fit this normally (but with a specified minimizer), we'd write

--- a/docs/fitting_types.rst
+++ b/docs/fitting_types.rst
@@ -129,8 +129,8 @@ Example::
     import numpy as np
 
     # Define the model for an exponential distribution (numpy style)
-    beta = Parameter()
-    x = Variable()
+    beta = Parameter('beta')
+    x = Variable('x')
     model = (1 / beta) * exp(-x / beta)
 
     # Draw 100 samples from an exponential distribution with beta=5.5
@@ -241,7 +241,7 @@ this::
     tdata = np.array([10, 26, 44, 70, 120])
     adata = 10e-4 * np.array([44, 34, 27, 20, 14])
     a, b, t = variables('a, b, t')
-    k = Parameter(0.1)
+    k = Parameter('k', 0.1)
     a0 = 54 * 10e-4
 
     model_dict = {
@@ -327,11 +327,11 @@ Let's plot the model for some kinetics constants::
 More common examples, such as dampened harmonic oscillators also work as expected::
 
     # Oscillator strength
-    k = Parameter()
+    k = Parameter('k')
     # Mass, just there for the physics
     m = 1
     # Dampening factor
-    gamma = Parameter()
+    gamma = Parameter('gamma')
 
     x, v, t = symfit.variables('x, v, t')
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -9,14 +9,14 @@ readable and easy to use fitting package which works for projects of any scale.
 :mod:`symfit` makes it extremely easy to provide guesses for your parameters
 and to bound them to a certain range::
 
-	a = Parameter(1.0, min=0.0, max=5.0)
+	a = Parameter('a', 1.0, min=0.0, max=5.0)
 
 To define models to fit to::
 
-	x = Variable()
-	A = Parameter()
-	sig = Parameter(1.0, min=0.0, max=5.0)
-	x0 = Parameter(1.0, min=0.0)
+	x = Variable('x')
+	A = Parameter('A')
+	sig = Parameter('sig', 1.0, min=0.0, max=5.0)
+	x0 = Parameter('x0', 1.0, min=0.0)
 
 	# Gaussian distrubution
 	model = A * exp(-(x - x0)**2/(2 * sig**2))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -9,9 +9,9 @@ The example below shows how easy it is to define a model that we could fit to.
 
   from symfit import Parameter, Variable
   
-  a = Parameter()
-  b = Parameter()
-  x = Variable()
+  a = Parameter('a')
+  b = Parameter('b')
+  x = Variable('x')
   model = a * x + b
 
 Lets fit this model to some generated data. ::
@@ -49,7 +49,7 @@ In the example above, we might change our
 :class:`~symfit.core.argument.Parameter`'s to the following after looking at a
 plot of the data::
 
-  k = Parameter(value=4, min=3, max=6)
+  k = Parameter('k', value=4, min=3, max=6)
 
   a, b = parameters('a, b')
   a.value = 60

--- a/symfit/contrib/interactive_guess/tests/test_interactive_fit.py
+++ b/symfit/contrib/interactive_guess/tests/test_interactive_fit.py
@@ -24,10 +24,10 @@ class Gaussian2DInteractiveGuessTest(unittest.TestCase):
     def setUpClass(cls):
         np.random.seed(0)
 
-        x = Variable()
-        y = Variable()
-        k = Parameter(900)
-        x0 = Parameter(1.5)
+        x = Variable('x')
+        y = Variable('y')
+        k = Parameter('k', 900)
+        x0 = Parameter('x0', 1.5)
 
         # You can NOT do this in one go. Blame Sympy. Not my fault.
         cls.k = k
@@ -113,11 +113,11 @@ class Gaussian2DInteractiveGuessTest(unittest.TestCase):
 class VectorValuedTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        x = Variable()
-        y1 = Variable()
-        y2 = Variable()
-        k = Parameter(900)
-        x0 = Parameter(1.5)
+        x = Variable('x')
+        y1 = Variable('y1')
+        y2 = Variable('y2')
+        k = Parameter('k', 900)
+        x0 = Parameter('x0', 1.5)
 
         model = {y1: k * (x-x0)**2,
                  y2: x - x0}
@@ -161,11 +161,11 @@ class Gaussian3DInteractiveFitTest(unittest.TestCase):
         xx, yy = np.meshgrid(xcentres, ycentres, sparse=False)
         xdata = np.dstack((xx, yy)).T # T because np fucks up conventions.
 
-        x0 = Parameter(0.6)
-        sig_x = Parameter(0.2, min=0.0)
+        x0 = Parameter(value=0.6)
+        sig_x = Parameter(value=0.2, min=0.0)
         x = Variable()
-        y0 = Parameter(0.4)
-        sig_y = Parameter(0.1, min=0.0)
+        y0 = Parameter(value=0.4)
+        sig_y = Parameter(value=0.1, min=0.0)
         A = Parameter()
         y = Variable()
         g = A * Gaussian(x, x0, sig_x) * Gaussian(y, y0, sig_y)

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -24,11 +24,12 @@ class Argument(Symbol):
         # Generate a dummy name
         if not name:
             # Throw a warning that is is better to explicitly give names.
-            warnings.warn(DeprecationWarning(
+            warnings.warn(
                 'It is recommended to provide names to {} explicitly'
                 ' as automatic generation of names will be dropped in '
-                'future `symfit` versions.'.format(cls.__name__)
-            ))
+                'future `symfit` versions.'.format(cls.__name__),
+                DeprecationWarning, stacklevel=2
+            )
 
             name = '{}_{}'.format(cls._argument_name, cls._argument_index)
             instance = super(Argument, cls).__new__(cls, name, **assumptions)
@@ -49,7 +50,7 @@ class Argument(Symbol):
 class Parameter(Argument):
     """
     Parameter objects are used to facilitate bounds on function parameters.
-    Important change from `symfit>=0.4.1`: the name needs to be the first keyword,
+    Important change from `symfit>0.4.1`: the name needs to be the first keyword,
     followed by the guess value. If no name is provided, the initial value can
     be passed as a keyword argument, e.g.: `value=0.1`. A generic name will then
     be generated.

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -1,4 +1,5 @@
 import numbers
+import warnings
 
 from sympy.core.symbol import Symbol
 
@@ -22,8 +23,15 @@ class Argument(Symbol):
         assumptions['real'] = True
         # Generate a dummy name
         if not name:
-            generated_name = '{}_{}'.format(cls._argument_name, cls._argument_index)
-            instance = super(Argument, cls).__new__(cls, generated_name, **assumptions)
+            # Throw a warning that is is better to explicitly give names.
+            warnings.warn(DeprecationWarning(
+                'It is recommended to provide names to {} explicitly'
+                ' as automatic generation of names will be dropped in '
+                'future `symfit` versions.'.format(cls.__name__)
+            ))
+
+            name = '{}_{}'.format(cls._argument_name, cls._argument_index)
+            instance = super(Argument, cls).__new__(cls, name, **assumptions)
             instance._argument_index = cls._argument_index
             cls._argument_index += 1
             return instance
@@ -56,7 +64,7 @@ class Parameter(Argument):
         except TypeError as err:
             if isinstance(name, numbers.Number):
                 raise TypeError('In symfit >0.4.1 the value needs to be assigned '
-                                'as the second argument or by keyword argument.') from err
+                                'as the second argument or by keyword argument.')
             else: raise err
 
     def __init__(self, name=None, value=1.0, min=None, max=None, fixed=False, **assumptions):

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -56,7 +56,7 @@ class Parameter(Argument):
     """
     # Parameter index to be assigned to generated nameless parameters
     _argument_index = 0
-    _argument_name = 'p'
+    _argument_name = '_p'
 
     def __new__(cls, name=None, *args, **kwargs):
         try:
@@ -95,4 +95,4 @@ class Variable(Argument):
     """ Variable type."""
     # Variable index to be assigned to generated nameless variables
     _argument_index = 0
-    _argument_name = 'x'
+    _argument_name = '_x'

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -1,70 +1,36 @@
-import os
-import sys
-import inspect
+import numbers
 
 from sympy.core.symbol import Symbol
-
-try: # This defines the basestring in both py2/py3.
-    basestring
-except NameError:
-    basestring = str
 
 class Argument(Symbol):
     """
     Base class for ``symfit`` symbols. This helps make ``symfit`` symbols distinguishable from ``sympy`` symbols.
 
-    The ``Argument`` class also makes DRY possible in defining ``Argument``'s: it uses ``inspect`` to read the lhs of the
-    assignment and uses that as the name for the ``Argument`` is none is explicitly set.
+    If no name is explicitly provided a name will be generated.
 
     For example::
 
-        x = Variable()
-        print(x.name)
-        >> 'x'
+        y = Variable()
+        print(y.name)
+        >> 'x_0'
+
+        y = Variable('y')
+        print(y.name)
+        >> 'y'
     """
-    def __new__(cls, name=None, **assumptions):
+    def __new__(cls, name=None, *args, **assumptions):
         assumptions['real'] = True
-        # Super dirty way? to determine the variable name from the calling line.
-        if not name or not isinstance(name, basestring):
-            frame, filename, line_number, function_name, lines, index = inspect.stack()[1]
+        # Generate a dummy name
+        if not name:
+            generated_name = '{}_{}'.format(cls._argument_name, cls._argument_index)
+            instance = super(Argument, cls).__new__(cls, generated_name, **assumptions)
+            instance._argument_index = cls._argument_index
+            cls._argument_index += 1
+            return instance
+        else:
+            return super(Argument, cls).__new__(cls, name, **assumptions)
 
-            # Check if the script is running in an exe
-            # If this is the case, symfit cannot find the vaiable name from the calling line and it will search
-            # in the exe directory to find the source. Make sure to copy the required source files for this to work.
-            if getattr(sys, 'frozen', False):
-                basedir = sys._MEIPASS #  Find the exe base dir
-                fname = os.path.basename(filename)
-                # Find the source file in the pyinstaller directory
-                source_file = None
-                for root, dirs, files in os.walk(basedir):
-                    if fname in files:
-                        source_file = os.path.join(root, fname)
-                        break
-
-                if source_file is None:
-                    raise IOError("Source code file not found")
-
-                # Get the correct line from the source code
-                l = 0
-                with open(source_file, 'r') as fid:
-                    for line in fid:
-                        l+=1
-                        if l == line_number:
-                            lines = line
-            caller = lines[0].strip()
-            if '==' in caller:
-                pass
-            else:
-                try:
-                    terms = caller.split('=')
-                except ValueError:
-                    generated_name = name
-                else:
-                    generated_name = terms[0].strip()  # lhs
-                return super(Argument, cls).__new__(cls, generated_name, **assumptions)
-        return super(Argument,cls).__new__(cls, name, **assumptions)
-
-    def __init__(self, name=None, **assumptions):
+    def __init__(self, name=None, *args, **assumptions):
         # TODO: A more careful look at Symbol.__init__ is needed! However, it
         # seems we don't have to pass anything on to it.
         if name is not None:
@@ -73,15 +39,34 @@ class Argument(Symbol):
 
 
 class Parameter(Argument):
-    """ Parameter objects are used to facilitate bounds on function parameters. """
-    def __init__(self, value=1.0, min=None, max=None, fixed=False, name=None, **assumptions):
+    """
+    Parameter objects are used to facilitate bounds on function parameters.
+    Important change from `symfit>=0.4.1`: the name needs to be the first keyword,
+    followed by the guess value. If no name is provided, the initial value can
+    be passed as a keyword argument, e.g.: `value=0.1`. A generic name will then
+    be generated.
+    """
+    # Parameter index to be assigned to generated nameless parameters
+    _argument_index = 0
+    _argument_name = 'p'
+
+    def __new__(cls, name=None, *args, **kwargs):
+        try:
+            return super(Parameter, cls).__new__(cls, name, *args, **kwargs)
+        except TypeError as err:
+            if isinstance(name, numbers.Number):
+                raise TypeError('In symfit >0.4.1 the value needs to be assigned '
+                                'as the second argument or by keyword argument.') from err
+            else: raise err
+
+    def __init__(self, name=None, value=1.0, min=None, max=None, fixed=False, **assumptions):
         """
+        :param name: Name of the Parameter.
         :param value: Initial guess value.
         :param min: Lower bound on the parameter value.
         :param max: Upper bound on the parameter value.
         :param fixed: Fix the parameter to ``value`` during fitting.
         :type fixed: bool
-        :param name: Name of the Parameter.
         :param assumptions: assumptions to pass to ``sympy``.
         """
         super(Parameter, self).__init__(name, **assumptions)
@@ -89,7 +74,6 @@ class Parameter(Argument):
         self.fixed = fixed
         if not self.fixed:
             if min is not None and max is not None and min > max:
-                print(min, max)
                 raise ValueError(
                     'The value of `min` should be less than or equal to the value of `max`.')
             else:
@@ -99,4 +83,6 @@ class Parameter(Argument):
 
 class Variable(Argument):
     """ Variable type."""
-    pass
+    # Variable index to be assigned to generated nameless variables
+    _argument_index = 0
+    _argument_name = 'x'

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -56,7 +56,7 @@ class Parameter(Argument):
     """
     # Parameter index to be assigned to generated nameless parameters
     _argument_index = 0
-    _argument_name = '_p'
+    _argument_name = 'par'
 
     def __new__(cls, name=None, *args, **kwargs):
         try:
@@ -95,4 +95,4 @@ class Variable(Argument):
     """ Variable type."""
     # Variable index to be assigned to generated nameless variables
     _argument_index = 0
-    _argument_name = '_x'
+    _argument_name = 'var'

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -687,7 +687,14 @@ class TakesData(object):
         ]
 
         signature = inspect_sig.Signature(parameters=parameters)
-        bound_arguments = signature.bind(*ordered_data, **named_data)
+        try:
+            bound_arguments = signature.bind(*ordered_data, **named_data)
+        except TypeError as err:
+            for var in self.model.vars:
+                if var.name.startswith(Variable._argument_name):
+                    raise type(err)(str(err) + '. Some of your Variable\'s are unnamed. That might be the cause of this Error: make sure you use e.g. x = Variable(\'x\')')
+            else:
+                raise err
         # Include default values in bound_argument object
         for param in signature.parameters.values():
             if param.name not in bound_arguments.arguments:

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -215,7 +215,7 @@ class LogLikelihood(GradientObjective):
 
         :param parameters: values for the fit parameters.
         :param apply_func: Function to apply to each component before returning it.
-            The default is to sum away along the datapoint dimension using `np.nansum'.
+            The default is to sum away along the datapoint dimension using `np.nansum`.
         :return: array of length number of ``Parameter``'s in the model, with all partial derivatives evaluated at p, data.
         """
         apply_func = parameters.pop('apply_func')

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -12,8 +12,9 @@ import warnings
 import numpy as np
 from sympy.utilities.lambdify import lambdify
 import sympy
-from sympy.tensor import IndexedBase
-from sympy import Symbol, symbols
+from sympy.tensor import Idx
+from sympy import symbols
+from sympy.core.expr import Expr
 
 from symfit.core.argument import Parameter, Variable
 
@@ -58,7 +59,10 @@ def seperate_symbols(func):
     for symbol in func.free_symbols:
         if isinstance(symbol, Parameter):
             params.append(symbol)
-        elif isinstance(symbol, (Variable, IndexedBase, Symbol)):
+        elif isinstance(symbol, Idx):
+            # Idx objects are not seen as parameters or vars.
+            pass
+        elif isinstance(symbol, Expr):
             vars.append(symbol)
         else:
             raise TypeError('model contains an unknown symbol type, {}'.format(type(symbol)))

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -120,7 +120,7 @@ def variables(names, **kwargs):
 
     :param names: string of variable names.
         Example: x, y = variables('x, y')
-    :param kwargs: kwargs to be passed onto :meth:`sympy.symbols`
+    :param kwargs: kwargs to be passed onto :func:`sympy.core.symbol.symbols`
     :return: iterable of :class:`symfit.core.Variable` objects
     """
     return symbols(names, cls=Variable, seq=True, **kwargs)
@@ -133,7 +133,7 @@ def parameters(names, **kwargs):
 
     :param names: string of parameter names.
         Example: a, b = parameters('a, b')
-    :param kwargs: kwargs to be passed onto :meth:`sympy.symbols`
+    :param kwargs: kwargs to be passed onto :func:`sympy.core.symbol.symbols`
     :return: iterable of :class:`symfit.core.Parameter` objects
     """
     return symbols(names, cls=Parameter, seq=True, **kwargs)

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -120,7 +120,7 @@ def variables(names, **kwargs):
     :param names: string of variable names.
         Example: x, y = variables('x, y')
     :param kwargs: kwargs to be passed onto :func:`sympy.core.symbol.symbols`
-    :return: iterable of :class:`symfit.core.Variable` objects
+    :return: iterable of :class:`symfit.core.argument.Variable` objects
     """
     return symbols(names, cls=Variable, seq=True, **kwargs)
 
@@ -132,7 +132,7 @@ def parameters(names, **kwargs):
     :param names: string of parameter names.
         Example: a, b = parameters('a, b')
     :param kwargs: kwargs to be passed onto :func:`sympy.core.symbol.symbols`
-    :return: iterable of :class:`symfit.core.Parameter` objects
+    :return: iterable of :class:`symfit.core.argument.Parameter` objects
     """
     return symbols(names, cls=Parameter, seq=True, **kwargs)
 

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -112,11 +112,10 @@ def sympy_to_scipy(func, vars, params):
 
     return f
 
-@deprecated('symbols(names, cls=Variable)')
 def variables(names, **kwargs):
     """
-    Convenience function for the creation of multiple variables. Deprecated:
-    use symbols(names, cls=Variable, **kwargs) instead.
+    Convenience function for the creation of multiple variables. For more
+    control, consider using symbols(names, cls=Variable, **kwargs) directly.
 
     :param names: string of variable names.
         Example: x, y = variables('x, y')
@@ -125,11 +124,10 @@ def variables(names, **kwargs):
     """
     return symbols(names, cls=Variable, seq=True, **kwargs)
 
-@deprecated('symbols(names, cls=Parameter)')
 def parameters(names, **kwargs):
     """
-    Convenience function for the creation of multiple parameters. Deprecated:
-    use symbols(names, cls=Parameter, **kwargs) instead.
+    Convenience function for the creation of multiple parameters. For more
+    control, consider using symbols(names, cls=Parameter, **kwargs) directly.
 
     :param names: string of parameter names.
         Example: a, b = parameters('a, b')

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -115,7 +115,7 @@ def sympy_to_scipy(func, vars, params):
 def variables(names, **kwargs):
     """
     Convenience function for the creation of multiple variables. For more
-    control, consider using symbols(names, cls=Variable, **kwargs) directly.
+    control, consider using ``symbols(names, cls=Variable, **kwargs)`` directly.
 
     :param names: string of variable names.
         Example: x, y = variables('x, y')
@@ -127,7 +127,7 @@ def variables(names, **kwargs):
 def parameters(names, **kwargs):
     """
     Convenience function for the creation of multiple parameters. For more
-    control, consider using symbols(names, cls=Parameter, **kwargs) directly.
+    control, consider using ``symbols(names, cls=Parameter, **kwargs)`` directly.
 
     :param names: string of parameter names.
         Example: a, b = parameters('a, b')

--- a/tests/test_analytical_fit.py
+++ b/tests/test_analytical_fit.py
@@ -210,8 +210,8 @@ class TestAnalyticalFit(unittest.TestCase):
         np.random.seed(10)
         yn = yn + np.random.normal(size=len(yn), scale=sigma)
 
-        a = Parameter()
-        y = Variable()
+        a = Parameter('a')
+        y = Variable('y')
         model = {y: a}
 
         fit = LinearLeastSquares(model, y=yn, sigma_y=sigma, absolute_sigma=False)
@@ -259,7 +259,7 @@ class TestAnalyticalFit(unittest.TestCase):
 
         # We now define our model
         t, y = variables('t, y')
-        g = Parameter(9.0)
+        g = Parameter('g', 9.0)
         t_model = {t: (2 * y / g)**0.5}
 
         # Different sigma for every point
@@ -284,11 +284,9 @@ class TestAnalyticalFit(unittest.TestCase):
         xdata = np.random.randint(-10, 11, size=(2, 100))
         zdata = 2.5*xdata[0]**2 + 7.0*xdata[1]**2
 
-        a = Parameter()
-        b = Parameter(10)
-        x = Variable()
-        y = Variable()
-        z = Variable()
+        a = Parameter('a')
+        b = Parameter(name='b', value=10)
+        x, y, z = variables('x, y, z')
         new = {z: a*x**2 + b*y**2}
 
         fit = NonLinearLeastSquares(new, x=xdata[0], y=xdata[1], z=zdata)

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -43,12 +43,12 @@ class TestArgument(unittest.TestCase):
         y = Variable('y')
 
         self.assertEqual(str(a), '{}_{}'.format(a._argument_name, a._argument_index))
-        self.assertEqual(str(a), 'p_{}'.format(a._argument_index))
+        self.assertEqual(str(a), 'par_{}'.format(a._argument_index))
         self.assertNotEqual(str(b), '{}_{}'.format(b._argument_name, b._argument_index))
         self.assertEqual(str(c), '{}_{}'.format(c._argument_name, c._argument_index))
         self.assertEqual(c.value, 10)
         self.assertEqual(b.value, 10)
-        self.assertEqual(str(x), 'x_{}'.format(x._argument_index))
+        self.assertEqual(str(x), 'var_{}'.format(x._argument_index))
         self.assertEqual(str(y), 'y')
 
         with self.assertRaises(TypeError):

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -1,0 +1,87 @@
+from __future__ import division, print_function
+import unittest
+import sys
+import sympy
+import warnings
+
+import numpy as np
+import scipy.stats
+from scipy.optimize import curve_fit, minimize
+
+from symfit import (
+    Variable, Parameter, Fit, FitResults, log, variables,
+    parameters, Model, Eq, Ge
+)
+from symfit.core.minimizers import BFGS, MINPACK, SLSQP, LBFGSB
+from symfit.core.objectives import LogLikelihood
+from symfit.distributions import Gaussian, Exp
+
+if sys.version_info >= (3, 0):
+    import inspect as inspect_sig
+else:
+    import funcsigs as inspect_sig
+
+
+class TestArgument(unittest.TestCase):
+    def test_parameter_add(self):
+        """
+        Makes sure the __add__ method of Parameters behaves as expected.
+        """
+        a = Parameter(value=1.0, min=0.5, max=1.5)
+        b = Parameter(value=1.0, min=0.0)
+        new = a + b
+        self.assertIsInstance(new, sympy.Add)
+
+    def test_argument_unnamed(self):
+        """
+        Make sure the generated parameter names follow the pattern
+        """
+        a = Parameter()
+        b = Parameter('b', 10)
+        c = Parameter(value=10)
+        x = Variable()
+        y = Variable('y')
+
+        self.assertEqual(str(a), '{}_{}'.format(a._argument_name, a._argument_index))
+        self.assertEqual(str(a), 'p_{}'.format(a._argument_index))
+        self.assertNotEqual(str(b), '{}_{}'.format(b._argument_name, b._argument_index))
+        self.assertEqual(str(c), '{}_{}'.format(c._argument_name, c._argument_index))
+        self.assertEqual(c.value, 10)
+        self.assertEqual(b.value, 10)
+        self.assertEqual(str(x), 'x_{}'.format(x._argument_index))
+        self.assertEqual(str(y), 'y')
+
+        with self.assertRaises(TypeError):
+            d = Parameter(10)
+
+
+    def test_argument_name(self):
+        """
+        Make sure that Parameters have a name attribute with the expected
+        value.
+        """
+        a = Parameter()
+        b = Parameter(name='b')
+        c = Parameter(name='d')
+        self.assertNotEqual(a.name, 'a')
+        self.assertEqual(b.name, 'b')
+        self.assertEqual(c.name, 'd')
+
+    def test_symbol_add(self):
+        """
+        Makes sure the __add__ method of symbols behaves as expected.
+        """
+        x, y = sympy.symbols('x y')
+        new = x + y
+        self.assertIsInstance(new, sympy.Add)
+
+if __name__ == '__main__':
+    try:
+        unittest.main(warnings='ignore')
+        # Note that unittest will catch and handle exceptions raised by tests.
+        # So this line will *only* deal with exceptions raised by the line
+        # above.
+    except TypeError:
+        # In Py2, unittest.main doesn't take a warnings argument
+        warnings.simplefilter('ignore')
+        unittest.main()

--- a/tests/test_auto_fit.py
+++ b/tests/test_auto_fit.py
@@ -242,13 +242,13 @@ class TestAutoFit(unittest.TestCase):
         xx, yy = np.meshgrid(xcentres, ycentres, sparse=False, indexing='ij')
 
         x0 = Parameter(value=mean[0], min=0.0, max=1.0)
-        sig_x = Parameter(0.2, min=0.0, max=0.3)
+        sig_x = Parameter(value=0.2, min=0.0, max=0.3)
         y0 = Parameter(value=mean[1], min=0.0, max=1.0)
-        sig_y = Parameter(0.1, min=0.0, max=0.3)
+        sig_y = Parameter(value=0.1, min=0.0, max=0.3)
         A = Parameter(value=np.mean(ydata), min=0.0)
-        x = Variable()
-        y = Variable()
-        g = Variable()
+        x = Variable('x')
+        y = Variable('y')
+        g = Variable('g')
 
         model = Model({g: A * Gaussian(x, x0, sig_x) * Gaussian(y, y0, sig_y)})
         fit = Fit(model, x=xx, y=yy, g=ydata)

--- a/tests/test_auto_fit.py
+++ b/tests/test_auto_fit.py
@@ -282,14 +282,14 @@ class TestAutoFit(unittest.TestCase):
         xx, yy = np.meshgrid(xcentres, ycentres, sparse=False, indexing='ij')
 
         x0 = Parameter(value=1.1 * mean[0], min=0.0, max=1.0)
-        sig_x = Parameter(1.1 * 0.2, min=0.0, max=0.3)
+        sig_x = Parameter(value=1.1 * 0.2, min=0.0, max=0.3)
         y0 = Parameter(value=1.1 * mean[1], min=0.0, max=1.0)
-        sig_y = Parameter(1.1 * 0.1, min=0.0, max=0.3)
+        sig_y = Parameter(value=1.1 * 0.1, min=0.0, max=0.3)
         A = Parameter(value=1.1 * np.mean(ydata), min=0.0)
         b = Parameter(value=1.2 * background, min=0.0)
-        x = Variable()
-        y = Variable()
-        g = Variable()
+        x = Variable('x')
+        y = Variable('y')
+        g = Variable('g')
 
         model = Model({g: A * Gaussian(x, x0, sig_x) * Gaussian(y, y0, sig_y) + b})
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -94,8 +94,8 @@ class TestConstrained(unittest.TestCase):
         xdata = np.linspace(1, 10, 10)
         ydata = 3*xdata**2
 
-        a = Parameter(1.0)
-        b = Parameter(2.5)
+        a = Parameter('a', 1.0)
+        b = Parameter('b', 2.5)
         x, y = variables('x, y')
         model = {y: a*x**b}
 
@@ -119,7 +119,7 @@ class TestConstrained(unittest.TestCase):
         yn = np.random.normal(size=xn.shape, scale=sigma)
 
         a = Parameter()
-        y = Variable()
+        y = Variable('y')
         model = {y: a}
 
         constr_fit = Fit(model, y=yn, sigma_y=sigma)
@@ -155,11 +155,11 @@ class TestConstrained(unittest.TestCase):
 
         zdata = (2.5*xx**2 + 3.0*yy**2)
 
-        a = Parameter(2.4, max=2.75)
-        b = Parameter(3.1, min=2.75)
-        x = Variable()
-        y = Variable()
-        z = Variable()
+        a = Parameter(value=2.4, max=2.75)
+        b = Parameter(value=3.1, min=2.75)
+        x = Variable('x')
+        y = Variable('y')
+        z = Variable('z')
         new = {z: a*x**2 + b*y**2}
 
         fit = Fit(new, x=xx, y=yy, z=zdata)
@@ -178,11 +178,11 @@ class TestConstrained(unittest.TestCase):
 
         zdata = (2.5*xx**2 + 3.0*yy**2)
 
-        a = Parameter(2.4, max=2.75)
-        b = Parameter(3.1, min=2.75)
-        x = Variable()
-        y = Variable()
-        z = Variable()
+        a = Parameter(value=2.4, max=2.75)
+        b = Parameter(value=3.1, min=2.75)
+        x = Variable('x')
+        y = Variable('y')
+        z = Variable('z')
         new = {z: a*x**2 + b*y**2}
 
         fit = Fit(new, x=xx, y=yy, z=zdata)
@@ -460,12 +460,12 @@ class TestConstrained(unittest.TestCase):
         xdata, ydata, zdata = [np.array(data) for data in zip(*data)]
         # errors = np.array([.4, .4, .2, .4, .1, .3, .1, .2, .2, .2])
 
-        a = Parameter(3.0)
-        b = Parameter(0.9)
-        c = Parameter(5.0)
-        x = Variable()
-        y = Variable()
-        z = Variable()
+        a = Parameter('a', 3.0)
+        b = Parameter('b', 0.9)
+        c = Parameter('c', 5.0)
+        x = Variable('x')
+        y = Variable('y')
+        z = Variable('z')
         model = {z: a * log(b * x + c * y)}
 
         const_fit = Fit(model, xdata, ydata, zdata, absolute_sigma=False)
@@ -506,13 +506,13 @@ class TestConstrained(unittest.TestCase):
         xx, yy = np.meshgrid(xcentres, ycentres, sparse=False, indexing='ij')
 
         x0 = Parameter(value=mean[0], min=0.0, max=1.0)
-        sig_x = Parameter(0.2, min=0.0, max=0.3)
+        sig_x = Parameter(value=0.2, min=0.0, max=0.3)
         y0 = Parameter(value=mean[1], min=0.0, max=1.0)
-        sig_y = Parameter(0.1, min=0.0, max=0.3)
+        sig_y = Parameter(value=0.1, min=0.0, max=0.3)
         A = Parameter(value=np.mean(ydata), min=0.0)
-        x = Variable()
-        y = Variable()
-        g = Variable()
+        x = Variable('x')
+        y = Variable('y')
+        g = Variable('g')
         model = Model({g: A * Gaussian(x, x0, sig_x) * Gaussian(y, y0, sig_y)})
         fit = Fit(model, x=xx, y=yy, g=ydata)
         fit_result = fit.execute()

--- a/tests/test_fit_result.py
+++ b/tests/test_fit_result.py
@@ -22,8 +22,8 @@ class TestFitResults(unittest.TestCase):
         xdata = np.linspace(1,10,10)
         ydata = 3*xdata**2
 
-        a = Parameter(3.0, min=2.75)
-        b = Parameter(2.0, max=2.75)
+        a = Parameter(value=3.0, min=2.75)
+        b = Parameter(value=2.0, max=2.75)
         x = Variable('x')
         new = a*x**b
 
@@ -96,17 +96,17 @@ class TestFitResults(unittest.TestCase):
         x = Variable()
         y = Variable()
 
-        x0_1 = Parameter(0.7, min=0.6, max=0.8)
-        sig_x_1 = Parameter(0.1, min=0.0, max=0.2)
-        y0_1 = Parameter(0.7, min=0.6, max=0.8)
-        sig_y_1 = Parameter(0.1, min=0.0, max=0.2)
+        x0_1 = Parameter(value=0.7, min=0.6, max=0.8)
+        sig_x_1 = Parameter(value=0.1, min=0.0, max=0.2)
+        y0_1 = Parameter(value=0.7, min=0.6, max=0.8)
+        sig_y_1 = Parameter(value=0.1, min=0.0, max=0.2)
         A_1 = Parameter()
         g_1 = A_1 * Gaussian(x, x0_1, sig_x_1) * Gaussian(y, y0_1, sig_y_1)
 
-        x0_2 = Parameter(0.3, min=0.2, max=0.4)
-        sig_x_2 = Parameter(0.1, min=0.0, max=0.2)
-        y0_2 = Parameter(0.3, min=0.2, max=0.4)
-        sig_y_2 = Parameter(0.1, min=0.0, max=0.2)
+        x0_2 = Parameter(value=0.3, min=0.2, max=0.4)
+        sig_x_2 = Parameter(value=0.1, min=0.0, max=0.2)
+        y0_2 = Parameter(value=0.3, min=0.2, max=0.4)
+        sig_y_2 = Parameter(value=0.1, min=0.0, max=0.2)
         A_2 = Parameter()
         g_2 = A_2 * Gaussian(x, x0_2, sig_x_2) * Gaussian(y, y0_2, sig_y_2)
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -65,6 +65,32 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(fit_result.value(a), 3.0)
         self.assertAlmostEqual(fit_result.value(b), 2.0)
 
+    def test_backwards_compatible_fitting(self):
+        """
+        In 0.4.2 we replaced the usage of inspect by automatically generated
+        names. This can cause problems for users using named variables to call
+        fit.
+        """
+        xdata = np.linspace(1, 10, 10)
+        ydata = 3*xdata**2
+
+        a = Parameter(value=1.0)
+        b = Parameter(value=2.5)
+
+        y = Variable('y')
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            x = Variable()
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+        model = {y: a*x**b}
+
+        with self.assertRaises(TypeError):
+            fit = Fit(model, x=xdata, y=ydata)
+
     def test_vector_fitting(self):
         """
         Tests fitting to a 3 component vector valued function, without bounds

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -53,8 +53,8 @@ class Tests(unittest.TestCase):
         xdata = np.linspace(1, 10, 10)
         ydata = 3*xdata**2
 
-        a = Parameter(1.0)
-        b = Parameter(2.5)
+        a = Parameter(value=1.0)
+        b = Parameter(value=2.5)
         x, y = variables('x, y')
 
         model = {y: a*x**b}
@@ -303,11 +303,11 @@ class Tests(unittest.TestCase):
 
         zdata = (2.5*xx**2 + 3.0*yy**2)
 
-        a = Parameter(2.5, max=2.75)
-        b = Parameter(3.0, min=2.75)
-        x = Variable()
-        y = Variable()
-        z = Variable()
+        a = Parameter(value=2.5, max=2.75)
+        b = Parameter(value=3.0, min=2.75)
+        x = Variable('x')
+        y = Variable('y')
+        z = Variable('z')
         new = {z: a*x**2 + b*y**2}
 
         fit = Fit(new, x=xx, y=yy, z=zdata)
@@ -376,10 +376,10 @@ class Tests(unittest.TestCase):
         xdata = np.random.randint(-10, 11, size=(2, 400))
         zdata = 2.5*xdata[0]**2 + 7.0*xdata[1]**2
 
-        a = Parameter()
-        b = Parameter()
-        x = Variable()
-        y = Variable()
+        a = Parameter('a')
+        b = Parameter('b')
+        x = Variable('x')
+        y = Variable('y')
         new = a*x**2 + b*y**2
 
         fit = Fit(new, xdata[0], xdata[1], zdata)
@@ -400,10 +400,10 @@ class Tests(unittest.TestCase):
         xdata = 2*np.random.rand(10000) - 1  # random betwen [-1, 1]
         ydata = 5.0 * scipy.stats.norm.pdf(xdata, loc=0.0, scale=1.0)
 
-        x0 = Parameter()
-        sig = Parameter()
-        A = Parameter()
-        x = Variable()
+        x0 = Parameter('x0')
+        sig = Parameter('sig')
+        A = Parameter('A')
+        x = Variable('x')
         g = A * Gaussian(x, x0, sig)
 
         fit = Fit(g, xdata, ydata)
@@ -445,20 +445,20 @@ class Tests(unittest.TestCase):
         xx, yy = np.meshgrid(xcentres, ycentres, sparse=False)
         # xdata = np.dstack((xx, yy)).T
 
-        x = Variable()
-        y = Variable()
+        x = Variable('x')
+        y = Variable('y')
 
-        x0_1 = Parameter(0.7, min=0.6, max=0.9)
-        sig_x_1 = Parameter(0.1, min=0.0, max=0.2)
-        y0_1 = Parameter(0.8, min=0.6, max=0.9)
-        sig_y_1 = Parameter(0.1, min=0.0, max=0.2)
+        x0_1 = Parameter(value=0.7, min=0.6, max=0.9)
+        sig_x_1 = Parameter(value=0.1, min=0.0, max=0.2)
+        y0_1 = Parameter(value=0.8, min=0.6, max=0.9)
+        sig_y_1 = Parameter(value=0.1, min=0.0, max=0.2)
         A_1 = Parameter()
         g_1 = A_1 * Gaussian(x, x0_1, sig_x_1) * Gaussian(y, y0_1, sig_y_1)
 
-        x0_2 = Parameter(0.3, min=0.2, max=0.5)
-        sig_x_2 = Parameter(0.1, min=0.0, max=0.2)
-        y0_2 = Parameter(0.4, min=0.2, max=0.5)
-        sig_y_2 = Parameter(0.1, min=0.0, max=0.2)
+        x0_2 = Parameter(value=0.3, min=0.2, max=0.5)
+        sig_x_2 = Parameter(value=0.1, min=0.0, max=0.2)
+        y0_2 = Parameter(value=0.4, min=0.2, max=0.5)
+        sig_y_2 = Parameter(value=0.1, min=0.0, max=0.2)
         A_2 = Parameter()
         g_2 = A_2 * Gaussian(x, x0_2, sig_x_2) * Gaussian(y, y0_2, sig_y_2)
 
@@ -500,12 +500,12 @@ class Tests(unittest.TestCase):
 
         x0 = Parameter(value=mean[0])
         sig_x = Parameter(min=0.0)
-        x = Variable()
+        x = Variable('x')
         y0 = Parameter(value=mean[1])
         sig_y = Parameter(min=0.0)
         A = Parameter(min=1, value=100)
-        y = Variable()
-        g = Variable()
+        y = Variable('y')
+        g = Variable('g')
 #        g = A * Gaussian(x, x0, sig_x) * Gaussian(y, y0, sig_y)
         model = Model({g: A * Gaussian(x, x0, sig_x) * Gaussian(y, y0, sig_y)})
         fit = Fit(model, x=xx, y=yy, g=ydata, minimizer=MINPACK)
@@ -532,7 +532,7 @@ class Tests(unittest.TestCase):
         """
         Fit using the likelihood method.
         """
-        b = Parameter(4, min=3.0)
+        b = Parameter(value=4, min=3.0)
         x, y = variables('x, y')
         pdf = {y: Exp(x, 1/b)}
 
@@ -580,56 +580,16 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(fit_result.stdev(mu) / mean_stdev, 1, 3)
         self.assertAlmostEqual(fit_result.value(sig) / np.std(xdata), 1, 6)
 
-    def test_parameter_add(self):
-        """
-        Makes sure the __add__ method of Parameters behaves as expected.
-        """
-        a = Parameter(value=1.0, min=0.5, max=1.5)
-        b = Parameter(1.0, min=0.0)
-        new = a + b
-        self.assertIsInstance(new, sympy.Add)
-
-    def test_argument_name(self):
-        """
-        Make sure that Parameters have a name attribute with the expected
-        value.
-        """
-        a = Parameter()
-        b = Parameter(name='b')
-        c = Parameter(name='d')
-        self.assertEqual(a.name, 'a')
-        self.assertEqual(b.name, 'b')
-        self.assertEqual(c.name, 'd')
-
-    def test_symbol_add(self):
-        """
-        Makes sure the __add__ method of symbols behaves as expected.
-        """
-        x, y = sympy.symbols('x y')
-        new = x + y
-        self.assertIsInstance(new, sympy.Add)
-
     def test_evaluate_model(self):
         """
         Makes sure that models are callable and give the expected answer.
         """
-        A = Parameter()
-        x = Variable()
+        A = Parameter('A')
+        x = Variable('x')
         new = A * x ** 2
 
         self.assertEqual(new(x=2, A=2), 8)
         self.assertNotEqual(new(x=2, A=3), 8)
-
-    # TODO: Do we really need to test this?
-    def test_symbol_object_add(self):
-        """
-        Makes sure the __add__ method of sympy's Symbol behaves as expected.
-        """
-        from sympy.core.symbol import Symbol
-        x = Symbol('x')
-        y = Symbol('y')
-        new = x + y
-        self.assertIsInstance(new, sympy.Add)
 
     def test_simple_sigma(self):
         """
@@ -700,12 +660,12 @@ class Tests(unittest.TestCase):
         errors = np.array([.4, .4, .2, .4, .1, .3, .1, .2, .2, .2])
 
         # raise Exception(xy, z)
-        a = Parameter(3.0)
-        b = Parameter(0.9)
-        c = Parameter(5)
+        a = Parameter(value=3.0)
+        b = Parameter(value=0.9)
+        c = Parameter(value=5)
         x = Variable()
         y = Variable()
-        z = Variable()
+        z = Variable('z')
         model = {z: a * log(b * x + c * y)}
 
         # fit = Fit(model, xy, z, absolute_sigma=False)
@@ -768,7 +728,7 @@ class Tests(unittest.TestCase):
         yn = np.random.normal(size=len(xn), scale=sigma)
 
         a = Parameter()
-        y = Variable()
+        y = Variable('y')
         model = {y: a}
 
         fit = Fit(model, y=yn, sigma_y=sigma)

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -26,8 +26,8 @@ class TestMinimize(unittest.TestCase):
         result.
         https://docs.scipy.org/doc/scipy-0.18.1/reference/tutorial/optimize.html#constrained-minimization-of-multivariate-scalar-functions-minimize
         """
-        x = Parameter(-1.0)
-        y = Parameter(1.0)
+        x = Parameter(value=-1.0)
+        y = Parameter(value=1.0)
         z = Variable()
         model = Model({z: 2*x*y + 2*x - x**2 - 2*y**2})
 
@@ -79,8 +79,8 @@ class TestMinimize(unittest.TestCase):
         self.assertAlmostEqual(fit_result.value(y), res.x[1], 6)
 
     def test_constraint_types(self):
-        x = Parameter(-1.0)
-        y = Parameter(1.0)
+        x = Parameter(value=-1.0)
+        y = Parameter(value=1.0)
         z = Variable()
         model = Model({z: 2*x*y + 2*x - x**2 - 2*y**2})
 

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -30,8 +30,8 @@ class TestMinimize(unittest.TestCase):
         ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
 
         # Normal symbolic fit
-        a = Parameter(value=0, min=0.0, max=1000)
-        b = Parameter(value=0, min=0.0, max=1000)
+        a = Parameter('a', value=0, min=0.0, max=1000)
+        b = Parameter('b', value=0, min=0.0, max=1000)
         x = Variable()
         model = a * x + b
 


### PR DESCRIPTION
Removed the inspect module usage to enforce DRY. This means the code is now more backwards compatible with sympy, at the expense of forcing users to write a little bit more code. However, the usage of inspect caused more problems then it solved. This might cure #60.

Now, if no name is provided, a dummy name is generated in the background, e.g.
```python
>>> a = Parameter()
>>> print(a)
p_0
```
```python
>>> a = Parameter('a')
>>> print(a)
a
```
```python
>>> a = Parameter('a', 5)
>>> print(a, a.value)
a, 5
```
```python
>>> a = Parameter(value=5)
>>> print(a, a.value)
p_0, 5
```
```python
>>> a = Parameter(5)
TypeError: In symfit >0.4.1 the value needs to be assigned as the second argument or by keyword argument.
```

I am now debating whether this is the way to go, or to just remove this entirely and to make users type out the names explicitly, just like `sympy`, since it prevents a lot of ambiguity.