### PR TITLE
Make parameters fully pickleable

### DIFF
--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -57,11 +57,8 @@ class Argument(Symbol):
 
     def __getstate__(self):
         state = super(Argument, self).__getstate__()
-        state.update(dict(
-            (slot, getattr(self, slot))
-            for slot in self.__slots__
-            if hasattr(self, slot)
-        ))
+        state.update({slot: getattr(self, slot) for slot in self.__slots__
+                      if hasattr(self, slot)})
         return state
 
 

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -4,10 +4,6 @@ import warnings
 
 from sympy.core.symbol import Symbol
 
-# This can not be a class attribute, since those become read only when they're
-# __slots__. Instead, make it a global dictionary of {class: count}.
-argument_indices = defaultdict(int)
-
 
 class Argument(Symbol):
     """
@@ -27,6 +23,9 @@ class Argument(Symbol):
         >> 'y'
     """
     __slots__ = ['_argument_index', '_argument_name']
+    # TODO: Make sure this also survives a pickle/unpickle to a fresh(!)
+    #       interpreter.
+    _argument_indices = defaultdict(int)
 
     def __new__(cls, name=None, *args, **assumptions):
         assumptions['real'] = True
@@ -40,12 +39,12 @@ class Argument(Symbol):
                 DeprecationWarning, stacklevel=2
             )
 
-            name = '{}_{}'.format(cls._argument_name, argument_indices[cls])
+            name = '{}_{}'.format(cls._argument_name, cls._argument_indices[cls])
             instance = super(Argument, cls).__new__(cls, name, **assumptions)
         else:
             instance = super(Argument, cls).__new__(cls, name, **assumptions)
-        instance._argument_index = argument_indices[cls]
-        argument_indices[cls] += 1
+        instance._argument_index = cls._argument_indices[cls]
+        cls._argument_indices[cls] += 1
         return instance
 
     def __init__(self, name=None, *args, **assumptions):

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -5,7 +5,8 @@ from sympy.core.symbol import Symbol
 
 class Argument(Symbol):
     """
-    Base class for ``symfit`` symbols. This helps make ``symfit`` symbols distinguishable from ``sympy`` symbols.
+    Base class for :mod:`symfit` symbols. This helps make :mod:`symfit` symbols
+    distinguishable from :mod:`sympy` symbols.
 
     If no name is explicitly provided a name will be generated.
 
@@ -46,6 +47,15 @@ class Argument(Symbol):
             self.name = name
         super(Argument, self).__init__()
 
+    def __getstate__(self):
+        state = super(Argument, self).__getstate__()
+        state.update(dict(
+            (slot, getattr(self, slot))
+            for slot in self.__slots__
+            if hasattr(self, slot)
+        ))
+        return state
+
 
 class Parameter(Argument):
     """
@@ -58,6 +68,7 @@ class Parameter(Argument):
     # Parameter index to be assigned to generated nameless parameters
     _argument_index = 0
     _argument_name = 'par'
+    __slots__ = ['min', 'max', 'fixed']
 
     def __new__(cls, name=None, *args, **kwargs):
         try:

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -90,9 +90,9 @@ class TestArgument(unittest.TestCase):
         Make sure Parameters and Variables don't have a __dict__
         """
         P = Parameter('P')
-        
-        print([x.__slots__ for x in Parameter.__mro__ if hasattr(x, '__slots__')])
 
+        # If you only have __slots__ you can't set arbitrary attributes, but
+        # you *should* be able to set those that are in your __slots__
         try:
             P.min = 0
         except AttributeError:

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -1,4 +1,5 @@
 from __future__ import division, print_function
+import pickle
 import unittest
 import sys
 import sympy
@@ -74,6 +75,16 @@ class TestArgument(unittest.TestCase):
         x, y = sympy.symbols('x y')
         new = x + y
         self.assertIsInstance(new, sympy.Add)
+
+    def test_pickle(self):
+        """
+        Make sure attributes are preserved when pickling
+        """
+        A = Parameter('A', min=0., max=1e3, fixed=True)
+        new_A = pickle.loads(pickle.dumps(A))
+        self.assertEqual((A.min, A.value, A.max, A.fixed, A.name),
+                         (new_A.min, new_A.value, new_A.max, new_A.fixed, new_A.name))
+
 
 if __name__ == '__main__':
     try:

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -85,6 +85,26 @@ class TestArgument(unittest.TestCase):
         self.assertEqual((A.min, A.value, A.max, A.fixed, A.name),
                          (new_A.min, new_A.value, new_A.max, new_A.fixed, new_A.name))
 
+    def test_slots(self):
+        """
+        Make sure Parameters and Variables don't have a __dict__
+        """
+        P = Parameter('P')
+        
+        print([x.__slots__ for x in Parameter.__mro__ if hasattr(x, '__slots__')])
+
+        try:
+            P.min = 0
+        except AttributeError:
+            self.fail()
+
+        with self.assertRaises(AttributeError):
+            P.foo = None
+
+        V = Variable('V')
+        with self.assertRaises(AttributeError):
+            V.bar = None
+
 
 if __name__ == '__main__':
     try:

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -85,6 +85,11 @@ class TestArgument(unittest.TestCase):
         self.assertEqual((A.min, A.value, A.max, A.fixed, A.name),
                          (new_A.min, new_A.value, new_A.max, new_A.fixed, new_A.name))
 
+        A = Parameter(min=0., max=1e3, fixed=True)
+        new_A = pickle.loads(pickle.dumps(A))
+        self.assertEqual((A.min, A.value, A.max, A.fixed, A.name),
+                         (new_A.min, new_A.value, new_A.max, new_A.fixed, new_A.name))
+
     def test_slots(self):
         """
         Make sure Parameters and Variables don't have a __dict__


### PR DESCRIPTION
It should be noted that the `__getstate__` from the sympy parent classes is wrong, so I made a new one. Symbol.name survives pickling via the __getnewargs__ method. We can't use that mechanism, since we need them to be passed to __init__.