### PR TITLE
The constraint example in the README suffered from a long time bug

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -53,14 +53,14 @@ class BaseModel(Mapping):
         """
         if not isinstance(model, Mapping):
             try:
-                enum = enumerate(model)
+                iter(model)
             except TypeError:
-                # The model is of length 1.
-                # TODO: this will break upon deprecating the auto-generation of
-                # names for Variables. At this time, a DummyVariable object
-                # should be introduced to fulfill the same role.
-                model = {Variable(): model}
-
+                # Model is still a scalar model
+                model = [model]
+            # TODO: this will break upon deprecating the auto-generation of
+            # names for Variables. At this time, a DummyVariable object
+            # should be introduced to fulfill the same role.
+            model = {Variable(): expr for expr in model}
         self._init_from_dict(model)
 
     def __len__(self):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -55,10 +55,11 @@ class BaseModel(Mapping):
             try:
                 enum = enumerate(model)
             except TypeError:
-                enum = enumerate([model])
-
-            model = {sympy.Dummy('y_{}'.format(index + 1)): expr for index, expr in enum}
-            # model = {Variable('dummy_{}'.format(index + 1)): expr for index, expr in enumerate(model)}
+                # The model is of length 1.
+                # TODO: this will break upon deprecating the auto-generation of
+                # names for Variables. At this time, a DummyVariable object
+                # should be introduced to fulfill the same role.
+                model = {Variable(): model}
 
         self._init_from_dict(model)
 

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -60,7 +60,11 @@ class BaseModel(Mapping):
             # TODO: this will break upon deprecating the auto-generation of
             # names for Variables. At this time, a DummyVariable object
             # should be introduced to fulfill the same role.
-            model = {Variable(): expr for expr in model}
+            # Also, catching the warnings should then be removed, as this is
+            # just to prevent the DeprecationWarning from appearing.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                model = {Variable(): expr for expr in model}
         self._init_from_dict(model)
 
     def __len__(self):

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -28,8 +28,8 @@ class TestMinimize(unittest.TestCase):
         """
         x = Parameter(value=-1.0)
         y = Parameter(value=1.0)
-        z = Variable()
-        model = Model({z: 2*x*y + 2*x - x**2 - 2*y**2})
+        # Use an  unnamed Variable on purpose to test the auto-generation of names.
+        model = Model(2 * x * y + 2 * x - x ** 2 - 2 * y ** 2)
 
         constraints = [
             Ge(y - 1, 0),  # y - 1 >= 0,


### PR DESCRIPTION
The constraint example in the README suffered from a long time bug when used as is, without naming the dependent_variable. Solved by using an automatically generated Variable instead of a Dummy symbol.