### PR TITLE
BasinHopping -> wraps scipy.optimize.basinhopping

### DIFF
--- a/docs/fitting_types.rst
+++ b/docs/fitting_types.rst
@@ -144,6 +144,7 @@ Example::
 As always, bounds on parameters and even constraints are supported.
 
 .. _minimize_maximize:
+
 Minimize/Maximize
 -----------------
 Minimize or Maximize a model subject to bounds and/or constraints. As an example

--- a/docs/fitting_types.rst
+++ b/docs/fitting_types.rst
@@ -367,7 +367,7 @@ More common examples, such as dampened harmonic oscillators also work as expecte
 
 Fitting multiple datasets
 -------------------------
-A common fitting problem, is to fit to multiple datasets. This is sometimes
+A common fitting problem is to fit to multiple datasets. This is sometimes
 referred to as global fitting. In such fits parameters might be shared
 between the fits to the different datasets. The same syntax used for ODE
 fitting makes this problem very easy to solve in :mod:`symfit`.
@@ -400,7 +400,7 @@ normal way::
    :width: 500px
    :alt: ODE integration
 
-Any ``Model`` that comes to mind is fair game, behind the scenes :mod:`symfit`
+Any ``Model`` that comes to mind is fair game. Behind the scenes :mod:`symfit`
 will build a least squares function where the residues of all the components
 are added squared, ready to be minimized. Unlike in the above example, the
 `x`-axis does not even have to be shared between the components.
@@ -483,7 +483,7 @@ compare to an example from the :mod:`scipy` docs::
     x0 = [1.0, 1.0]
     ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs, niter=200)
 
-Let's compare to the same functionality in :mod:`symfit`
+Let's compare to the same functionality in :mod:`symfit`::
 
     import numpy as np
     from symfit.core.minimizers import BasinHopping
@@ -505,7 +505,7 @@ using `L-BFGS-B` instead. Setting bounds is as simple as::
     x1.min = 0.0
     x1.max = 100.0
 
-However, the real strength the `symfit` syntax lies in providing constraints::
+However, the real strength of the `symfit` syntax lies in providing constraints::
 
     constraints = [Eq(x1, x2)]
     fit = Fit(model, minimizer=BasinHopping, constraints=constraints)

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -11,9 +11,9 @@ from scipy.optimize import minimize
 from scipy.integrate import odeint
 
 from symfit.core.argument import Parameter, Variable
-from .support import \
-    seperate_symbols, keywordonly, sympy_to_py, cache, key2str, partial
-
+from .support import (
+    seperate_symbols, keywordonly, sympy_to_py, key2str, partial, cached_property
+)
 from .minimizers import (
     BFGS, SLSQP, LBFGSB, BaseMinimizer, GradientMinimizer, ConstrainedMinimizer,
     ScipyMinimize, MINPACK, ChainedMinimizer, BasinHopping
@@ -149,8 +149,7 @@ class BaseModel(Mapping):
         # Make Variable object corresponding to each var.
         self.sigmas = {var: Variable(name='sigma_{}'.format(var.name)) for var in self.dependent_vars}
 
-    @property
-    @cache
+    @cached_property
     def vars(self):
         """
         :return: Returns a list of dependent, independent and sigma variables, in that order.
@@ -244,8 +243,7 @@ class CallableModel(BaseModel):
         # return Ans(*[component(**bound_arguments.arguments) for component in self.numerical_components])
         return Ans(*self.eval_components(**bound_arguments.arguments))
 
-    @property
-    # @cache
+    @cached_property
     def numerical_components(self):
         """
         :return: lambda functions of each of the components in model_dict, to be used in numerical calculation.
@@ -357,7 +355,6 @@ class Model(CallableModel):
         return "\n".join(parts)
 
     @property
-    # @cache
     def jacobian(self):
         """
         :return: Jacobian 'Matrix' filled with the symbolic expressions for all the partial derivatives.
@@ -367,7 +364,6 @@ class Model(CallableModel):
         return [[sympy.diff(expr, param) for param in self.params] for expr in self.values()]
 
     @property
-    # @cache
     def chi_squared(self):
         """
         :return: Symbolic :math:`\\chi^2`
@@ -375,7 +371,6 @@ class Model(CallableModel):
         return sum(((f - y)/self.sigmas[y])**2 for y, f in self.items())
 
     @property
-    # @cache
     def chi(self):
         """
         :return: Symbolic Square root of :math:`\\chi^2`. Required for MINPACK optimization only. Denoted as :math:`\\sqrt(\\chi^2)`
@@ -383,7 +378,6 @@ class Model(CallableModel):
         return sympy.sqrt(self.chi_squared)
 
     @property
-    # @cache
     def chi_jacobian(self):
         """
         Return a symbolic jacobian of the :math:`\\sqrt(\\chi^2)` function.
@@ -397,7 +391,6 @@ class Model(CallableModel):
         return jac
 
     @property
-    # @cache
     def chi_squared_jacobian(self):
         """
         Return a symbolic jacobian of the :math:`\\chi^2` function.
@@ -411,48 +404,41 @@ class Model(CallableModel):
         return jac
 
     # @property
-    # # @cache
     # def ss_res(self):
     #     """
     #     :return: Residual sum of squares. Similar to chi_squared, but without considering weights.
     #     """
     #     return sum((y - f)**2 for y, f in self.items())
 
-
-    @property
-    # @cache
+    @cached_property
     def numerical_jacobian(self):
         """
         :return: lambda functions of the jacobian matrix of the function, which can be used in numerical optimization.
         """
         return [[sympy_to_py(partial_dv, self.independent_vars, self.params) for partial_dv in row] for row in self.jacobian]
 
-    @property
-    # @cache
+    @cached_property
     def numerical_chi_squared(self):
         """
         :return: lambda function of the ``.chi_squared`` method, to be used in numerical optimisation.
         """
         return sympy_to_py(self.chi_squared, self.vars, self.params)
 
-    @property
-    # @cache
+    @cached_property
     def numerical_chi(self):
         """
         :return: lambda function of the ``.chi`` method, to be used in MINPACK optimisation.
         """
         return sympy_to_py(self.chi, self.vars, self.params)
 
-    @property
-    # @cache
+    @cached_property
     def numerical_chi_jacobian(self):
         """
         :return: lambda functions of the jacobian of the ``.chi`` method, which can be used in numerical optimization.
         """
         return [sympy_to_py(component, self.vars, self.params) for component in self.chi_jacobian]
 
-    @property
-    # @cache
+    @cached_property
     def numerical_chi_squared_jacobian(self):
         """
         :return: lambda functions of the jacobian of the ``.chi_squared`` method.
@@ -624,7 +610,6 @@ class Constraint(Model):
         return self.__class__(new_constraint, self.model)
 
     @property
-    # @cache
     def jacobian(self):
         """
         :return: Jacobian 'Matrix' filled with the symbolic expressions for all the partial derivatives.
@@ -633,16 +618,14 @@ class Constraint(Model):
         """
         return [[sympy.diff(expr, param) for param in self.model.params] for expr in self.values()]
 
-    @property
-    # @cache
+    @cached_property
     def numerical_components(self):
         """
         :return: lambda functions of each of the components in model_dict, to be used in numerical calculation.
         """
         return [sympy_to_py(expr, self.model.vars, self.model.params) for expr in self.values()]
 
-    @property
-    # @cache
+    @cached_property
     def numerical_jacobian(self):
         """
         :return: lambda functions of the jacobian matrix of the function, which can be used in numerical optimization.
@@ -1788,13 +1771,11 @@ class ODEModel(CallableModel):
             new_model_dict[key] *= -1
         return self.__class__(new_model_dict, initial=self.initial)
 
-    @property
-    @cache
+    @cached_property
     def _ncomponents(self):
         return [sympy_to_py(expr, self.independent_vars + self.dependent_vars, self.params) for expr in self.values()]
 
-    @property
-    @cache
+    @cached_property
     def _njacobian(self):
         return [
             [sympy_to_py(sympy.diff(expr, var), self.independent_vars + self.dependent_vars, self.params) for var in self.dependent_vars]

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -469,17 +469,17 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
     :class:`~symfit.core.fit.Fit`, as this will automatically select a local
     minimizer for you depending on whether you provided bounds, constraints, etc.
 
-    However, BasinHopping can also be used directly. Example with jacobian::
+    However, BasinHopping can also be used directly. Example (with jacobian)::
 
         import numpy as np
         from symfit.core.minimizers import BFGS, BasinHopping
         from symfit import parameters
 
-        def func2d_symfit(x1, x2):
+        def func2d(x1, x2):
             f = np.cos(14.5 * x1 - 0.3) + (x2 + 0.2) * x2 + (x1 + 0.2) * x1
             return f
 
-        def jac2d_symfit(x1, x2):
+        def jac2d(x1, x2):
             df = np.zeros(2)
             df[0] = -14.5 * np.sin(14.5 * x1 - 0.3) + 2. * x1 + 0.2
             df[1] = 2. * x2 + 0.2
@@ -488,8 +488,8 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
         x0 = [1.0, 1.0]
         np.random.seed(555)
         x1, x2 = parameters('x1, x2', value=x0)
-        fit = BasinHopping(func2d_symfit, [x1, x2], local_minimizer=BFGS)
-        minimizer_kwargs = {'jac': fit.list2kwargs(jac2d_symfit)}
+        fit = BasinHopping(func2d, [x1, x2], local_minimizer=BFGS)
+        minimizer_kwargs = {'jac': fit.list2kwargs(jac2d)}
         fit_result = fit.execute(niter=200, minimizer_kwargs=minimizer_kwargs)
 
     See :func:`scipy.optimize.basinhopping` for more options.
@@ -527,12 +527,19 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
             self.local_minimizer = self.local_minimizer(self.objective, self.parameters)
 
     def execute(self, **minimize_options):
+        """
+        Execute the basin-hopping minimization.
+        
+        :param minimize_options: options to be passed on to
+            :func:`scipy.optimize.basinhopping`.
+        :return: :class:`symfit.core.fit_results.FitResults`
+        """
         if 'minimizer_kwargs' not in minimize_options:
             minimize_options['minimizer_kwargs'] = {}
 
         if 'method' not in minimize_options['minimizer_kwargs']:
             # If no minimizer was set by the user upon execute, use the default.
-            minimize_options['minimizer_kwargs']['method'] = self.local_minimizer.minimize_method()
+            minimize_options['minimizer_kwargs']['method'] = self.local_minimizer.method_name()
         if 'jac' not in minimize_options['minimizer_kwargs'] and isinstance(self.local_minimizer, GradientMinimizer):
             # Assign the jacobian
             minimize_options['minimizer_kwargs']['jac'] = self.local_minimizer.wrapped_jacobian

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -270,6 +270,7 @@ class ScipyMinimize(object):
         ans = minimize(
             self.wrapped_objective,
             self.initial_guesses,
+            method=self.method_name(),
             bounds=bounds,
             constraints=constraints,
             jac=jacobian,
@@ -317,7 +318,7 @@ class ScipyMinimize(object):
         return FitResults(**fit_results)
 
     @classmethod
-    def minimize_method(cls):
+    def method_name(cls):
         """
         Returns the name of the minimize method this object represents. This is
         needed because the name of the object is not always exactly what needs
@@ -377,8 +378,6 @@ class BFGS(ScipyGradientMinimize):
     """
     Wrapper around :func:`scipy.optimize.minimize`'s BFGS algorithm.
     """
-    def execute(self, **minimize_options):
-        return super(BFGS, self).execute(method='BFGS', **minimize_options)
 
 class DifferentialEvolution(ScipyMinimize, GlobalMinimizer, BoundedMinimizer):
     """
@@ -406,7 +405,6 @@ class SLSQP(ScipyConstrainedMinimize, GradientMinimizer, BoundedMinimizer):
 
     def execute(self, **minimize_options):
         return super(SLSQP, self).execute(
-            method='SLSQP',
             bounds=self.bounds,
             jacobian=self.wrapped_jacobian,
             **minimize_options
@@ -439,11 +437,6 @@ class COBYLA(ScipyConstrainedMinimize):
     """
     Wrapper around :func:`scipy.optimize.minimize`'s COBYLA algorithm.
     """
-    def execute(self, **minimize_options):
-        return super(COBYLA, self).execute(
-            method='COBYLA', **minimize_options
-        )
-
 
 class LBFGSB(ScipyGradientMinimize, BoundedMinimizer):
     """
@@ -451,13 +444,12 @@ class LBFGSB(ScipyGradientMinimize, BoundedMinimizer):
     """
     def execute(self, **minimize_options):
         return super(LBFGSB, self).execute(
-            method='L-BFGS-B',
             bounds=self.bounds,
             **minimize_options
         )
 
     @classmethod
-    def minimize_method(cls):
+    def method_name(cls):
         return "L-BFGS-B"
 
 class NelderMead(ScipyMinimize, BaseMinimizer):
@@ -465,11 +457,8 @@ class NelderMead(ScipyMinimize, BaseMinimizer):
     Wrapper around :func:`scipy.optimize.minimize`'s NelderMead algorithm.
     """
     @classmethod
-    def minimize_method(cls):
+    def method_name(cls):
         return 'Nelder-Mead'
-
-    def execute(self, **minimize_options):
-        return super(NelderMead, self).execute(method='Nelder-Mead', **minimize_options)
 
 
 class BasinHopping(ScipyMinimize, BaseMinimizer):

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -538,7 +538,7 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
             minimize_options['minimizer_kwargs'] = {}
 
         if 'method' not in minimize_options['minimizer_kwargs']:
-            # If no minimizer was set by the user upon execute, use the default.
+            # If no minimizer was set by the user upon execute, use local_minimizer
             minimize_options['minimizer_kwargs']['method'] = self.local_minimizer.method_name()
         if 'jac' not in minimize_options['minimizer_kwargs'] and isinstance(self.local_minimizer, GradientMinimizer):
             # Assign the jacobian

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -478,7 +478,7 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
 
     As always, the best way to use this algorithm is through
     :class:`~symfit.core.fit.Fit`, as this will automatically select a local
-    minimizer for you depending on wether you provvided ounds, constraints, etc.
+    minimizer for you depending on whether you provided bounds, constraints, etc.
 
     However, BasinHopping can also be used directly. Example with jacobian::
 

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -525,6 +525,10 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
         if 'constraints' not in minimize_options['minimizer_kwargs'] and isinstance(self.local_minimizer, ConstrainedMinimizer):
             # Assign constraints
             minimize_options['minimizer_kwargs']['constraints'] = self.local_minimizer.wrapped_constraints
+        if 'bounds' not in minimize_options['minimizer_kwargs'] and isinstance(self.local_minimizer, BoundedMinimizer):
+            # Assign bounds
+            minimize_options['minimizer_kwargs']['bounds'] = self.local_minimizer.bounds
+
         ans = basinhopping(
             self.wrapped_objective,
             self.initial_guesses,

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -456,11 +456,18 @@ class LBFGSB(ScipyGradientMinimize, BoundedMinimizer):
             **minimize_options
         )
 
+    @classmethod
+    def minimize_method(cls):
+        return "L-BFGS-B"
 
 class NelderMead(ScipyMinimize, BaseMinimizer):
     """
     Wrapper around :func:`scipy.optimize.minimize`'s NelderMead algorithm.
     """
+    @classmethod
+    def minimize_method(cls):
+        return 'Nelder-Mead'
+
     def execute(self, **minimize_options):
         return super(NelderMead, self).execute(method='Nelder-Mead', **minimize_options)
 

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -4,7 +4,7 @@ from six import add_metaclass
 
 import numpy as np
 
-from .support import cache, keywordonly, key2str
+from .support import cached_property, keywordonly, key2str
 
 @add_metaclass(abc.ABCMeta)
 class BaseObjective(object):
@@ -19,8 +19,7 @@ class BaseObjective(object):
         self.model = model
         self.data = data
 
-    @property
-    @cache
+    @cached_property
     def dependent_data(self):
         """
         Read-only Property
@@ -31,8 +30,7 @@ class BaseObjective(object):
         """
         return OrderedDict((var, self.data[var]) for var in self.model)
 
-    @property
-    @cache
+    @cached_property
     def independent_data(self):
         """
         Read-only Property
@@ -44,8 +42,7 @@ class BaseObjective(object):
         return OrderedDict((var, self.data[var]) for var in
                            self.model.independent_vars)
 
-    @property
-    @cache
+    @cached_property
     def sigma_data(self):
         """
         Read-only Property

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -4,13 +4,15 @@ import sys
 import warnings
 
 import numpy as np
-from scipy.optimize import minimize
+from scipy.optimize import minimize, basinhopping
 
 from symfit import (
-    Variable, Parameter, Eq, Ge, Le, Lt, Gt, Ne, parameters, ModelError, Fit, Model
+    Variable, Parameter, Eq, Ge, Le, Lt, Gt, Ne, parameters, ModelError, Fit,
+    Model, cos
 )
 from symfit.core.objectives import MinimizeModel
-from symfit.core.minimizers import BFGS
+from symfit.core.minimizers import BFGS, BasinHopping, LBFGSB
+from symfit.core.support import partial
 
 
 class TestMinimize(unittest.TestCase):
@@ -116,6 +118,106 @@ class TestMinimize(unittest.TestCase):
         self.assertAlmostEqual(fit_result.value(x), std_result.value(x))
         self.assertAlmostEqual(fit_result.value(y), std_result.value(y))
 
+    def test_basinhopping_large(self):
+        """
+        Test the basinhopping method of scipy.minimize. This is based of scipy's docs
+        as found here: https://docs.scipy.org/doc/scipy-0.13.0/reference/generated/scipy.optimize.anneal.html
+        """
+        def f1(z, *params):
+            x, y = z
+            a, b, c, d, e, f, g, h, i, j, k, l, scale = params
+            return (a * x ** 2 + b * x * y + c * y ** 2 + d * x + e * y + f)
+
+        def f2(z, *params):
+            x, y = z
+            a, b, c, d, e, f, g, h, i, j, k, l, scale = params
+            return (-g * np.exp(-((x - h) ** 2 + (y - i) ** 2) / scale))
+
+        def f3(z, *params):
+            x, y = z
+            a, b, c, d, e, f, g, h, i, j, k, l, scale = params
+            return (-j * np.exp(-((x - k) ** 2 + (y - l) ** 2) / scale))
+
+        def func(z, *params):
+            x, y = z
+            a, b, c, d, e, f, g, h, i, j, k, l, scale = params
+            return f1(z, *params) + f2(z, *params) + f3(z, *params)
+
+        def f_symfit(x1, x2, params):
+            z = [x1, x2]
+            return func(z, *params)
+
+        params = (2, 3, 7, 8, 9, 10, 44, -1, 2, 26, 1, -2, 0.5)
+
+        x0 = np.array([2., 2.])
+        np.random.seed(555)
+        res = basinhopping(func, x0, minimizer_kwargs={'args': params})
+
+        np.random.seed(555)
+        x1, x2 = parameters('x1, x2', value=x0)
+        fit = BasinHopping(partial(f_symfit, params=params), [x1, x2])
+        fit_result = fit.execute()
+
+        self.assertEqual(res.x[0], fit_result.value(x1))
+        self.assertEqual(res.x[1], fit_result.value(x2))
+        self.assertEqual(res.fun, fit_result.objective_value)
+
+    def test_basinhopping(self):
+        func = lambda x: np.cos(14.5 * x - 0.3) + (x + 0.2) * x
+        x0 = [1.]
+        np.random.seed(555)
+        res = basinhopping(func, x0, minimizer_kwargs={"method": "BFGS"}, niter=200)
+        print(res)
+        np.random.seed(555)
+        x, = parameters('x')
+        fit = BasinHopping(func, [x])
+        fit_result = fit.execute(minimizer_kwargs={"method": "BFGS", 'jac': False}, niter=200)
+        print(fit_result)
+
+        self.assertEqual(res.x, fit_result.value(x))
+        self.assertEqual(res.fun, fit_result.objective_value)
+
+    def test_basinhopping_2d(self):
+        def func2d(x):
+            f = np.cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] + 0.2) * x[0]
+            df = np.zeros(2)
+            df[0] = -14.5 * np.sin(14.5 * x[0] - 0.3) + 2. * x[0] + 0.2
+            df[1] = 2. * x[1] + 0.2
+            return f, df
+
+        def func2d_symfit(x1, x2):
+            f = np.cos(14.5 * x1 - 0.3) + (x2 + 0.2) * x2 + (x1 + 0.2) * x1
+            return f
+
+        def jac2d_symfit(x1, x2):
+            df = np.zeros(2)
+            df[0] = -14.5 * np.sin(14.5 * x1 - 0.3) + 2. * x1 + 0.2
+            df[1] = 2. * x2 + 0.2
+            return df
+
+        np.random.seed(555)
+        minimizer_kwargs = {'method': 'BFGS', 'jac': True}
+        x0 = [1.0, 1.0]
+        res = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs, niter=200)
+
+        np.random.seed(555)
+        x1, x2 = parameters('x1, x2', value=x0)
+        fit = BasinHopping(func2d_symfit, [x1, x2], local_minimizer=BFGS)
+        minimizer_kwargs = {'jac': fit.list2kwargs(jac2d_symfit)}
+        fit_result = fit.execute(niter=200, minimizer_kwargs=minimizer_kwargs)
+
+        self.assertEqual(res.x[0], fit_result.value(x1))
+        self.assertEqual(res.x[1], fit_result.value(x2))
+        self.assertEqual(res.fun, fit_result.objective_value)
+
+        # Now compare with the symbolic equivalent
+        np.random.seed(555)
+        model = cos(14.5 * x1 - 0.3) + (x2 + 0.2) * x2 + (x1 + 0.2) * x1
+        fit = Fit(model, minimizer=BasinHopping)
+        fit_result = fit.execute()
+        self.assertEqual(res.x[0], fit_result.value(x1))
+        self.assertEqual(res.x[1], fit_result.value(x2))
+        self.assertEqual(res.fun, fit_result.objective_value)
 
 
 if __name__ == '__main__':

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -219,7 +219,7 @@ class TestMinimize(unittest.TestCase):
         self.assertEqual(res.x[1], fit_result.value(x2))
         self.assertEqual(res.fun, fit_result.objective_value)
         self.assertIsInstance(fit.minimizer.local_minimizer, BFGS)
-        
+
         # Impose constrains
         np.random.seed(555)
         model = cos(14.5 * x1 - 0.3) + (x2 + 0.2) * x2 + (x1 + 0.2) * x1

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -6,6 +6,7 @@ from __future__ import division, print_function
 import unittest
 import sys
 import warnings
+from itertools import repeat
 
 from symfit.core.support import \
     keywordonly, RequiredKeyword, RequiredKeywordError, partial, parameters
@@ -182,6 +183,8 @@ class TestSupport(unittest.TestCase):
         # Illegal bounds
         with self.assertRaises(ValueError):
             x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=[400, -10], max=[300, 100])
+        # Should not raise any error, as repeat is an endless source of values
+        x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=repeat(0.0))
 
 if __name__ == '__main__':
     try:

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 
 from symfit.core.support import \
-    keywordonly, RequiredKeyword, RequiredKeywordError, partial
+    keywordonly, RequiredKeyword, RequiredKeywordError, partial, parameters
 
 if sys.version_info >= (3, 0):
     import inspect as inspect_sig
@@ -155,6 +155,33 @@ class TestSupport(unittest.TestCase):
         self.assertFalse(partialed_two.args)
         self.assertEqual(partialed_two.keywords, {'a': 2, 'b': 'string'})
 
+    def test_parameters(self):
+        """
+        Test the `parameter` convenience function.
+        """
+        x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=0.0)
+        self.assertEqual(x1.value, 2.0)
+        self.assertEqual(x2.value, 1.3)
+        self.assertEqual(x1.min, 0.0)
+        self.assertEqual(x2.min, 0.0)
+        self.assertEqual(x1.fixed, False)
+        self.assertEqual(x2.fixed, False)
+        with self.assertRaises(ValueError):
+            x1, x2 = parameters('x1, x2', value=[2.0, 1.3, 3.0], min=0.0)
+
+        x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=[-30, -10], max=[300, 100], fixed=[True, False])
+        self.assertEqual(x1.min, -30)
+        self.assertEqual(x2.min, -10)
+        self.assertEqual(x1.max, 300)
+        self.assertEqual(x2.max, 100)
+        self.assertEqual(x1.value, 2.0)
+        self.assertEqual(x2.value, 1.3)
+        self.assertEqual(x1.fixed, True)
+        self.assertEqual(x2.fixed, False)
+
+        # Illegal bounds
+        with self.assertRaises(ValueError):
+            x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=[400, -10], max=[300, 100])
 
 if __name__ == '__main__':
     try:

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -190,8 +190,12 @@ class TestSupport(unittest.TestCase):
 
     def test_cached_property(self):
         class A(object):
+            def __init__(self):
+                self.counter = 0
+
             @cached_property
             def f(self):
+                self.counter += 1
                 return 2
 
         a = A()
@@ -212,6 +216,14 @@ class TestSupport(unittest.TestCase):
         with self.assertRaises(AttributeError):
             # Setting is not allowed.
             a.f = 3
+
+        # Counter should read 2 at this point, the number of calls since
+        # object creation.
+        self.assertEqual(a.counter, 2)
+        for _ in range(10):
+            a.f
+        # Should be returning from cache, so a.f is not actually called
+        self.assertEqual(a.counter, 2)
 
 if __name__ == '__main__':
     try:

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -8,8 +8,10 @@ import sys
 import warnings
 from itertools import repeat
 
-from symfit.core.support import \
-    keywordonly, RequiredKeyword, RequiredKeywordError, partial, parameters
+from symfit.core.support import (
+    keywordonly, RequiredKeyword, RequiredKeywordError, partial, parameters,
+    cached_property
+)
 
 if sys.version_info >= (3, 0):
     import inspect as inspect_sig
@@ -185,6 +187,31 @@ class TestSupport(unittest.TestCase):
             x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=[400, -10], max=[300, 100])
         # Should not raise any error, as repeat is an endless source of values
         x1, x2 = parameters('x1, x2', value=[2.0, 1.3], min=repeat(0.0))
+
+    def test_cached_property(self):
+        class A(object):
+            @cached_property
+            def f(self):
+                return 2
+
+        a = A()
+        # Deleta before a cache was set will fail silently.
+        del a.f
+        with self.assertRaises(AttributeError):
+            # Cache does not exist before f is called
+            a._f
+        self.assertEqual(a.f, 2)
+        self.assertTrue(hasattr(a, '_f'))
+        del a.f
+        # check that deletion was successful
+        with self.assertRaises(AttributeError):
+            # Does not exist before f is called
+            a._f
+        # However, the function should still be there
+        self.assertEqual(a.f, 2)
+        with self.assertRaises(AttributeError):
+            # Setting is not allowed.
+            a.f = 3
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
This PR wraps `scipy.optimize.basinhopping` into a friendly `symfit` minimizer. When used through `Fit` (recommended) the full feature set of `symfit` is easily available: `symfit` provides the jacobian automatically,and we have automatic support of bounds and constraints through the standard API.

To do:

- [x] check the performance. I noticed that the direct call to `scipy.optimize.basinhopping` and `BasinHopping` are fast, but when done through `Fit` the performance seems significantly worse. (From answering directly to having to wait a couple of seconds) It has to be investigated weather this is due to overhead, or that every evaluation is more expensive because of all the wrapping and partialing functions `symfit` does this way.
- [x] Write docs.
- [x] Use `cls.minimize_method` by default to determine the method of `ScipyMinimize`'s children, to reduce boiler plate.

If this is suitable to large numbers of parameters then I intend to use this as the default solver for future `IndexedParameter`'s if no quick-fire solution is known. If not, we might need to wrap a true monte-carlo package to do that.