### PR TITLE
Pickle fit results & Models

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -211,6 +211,15 @@ class BaseModel(Mapping):
             )
         return "\n".join(parts)
 
+    def __getstate__(self):
+        # Remove cached_property values from the state, they need to be
+        # re-calculated after pickle.
+        state = self.__dict__.copy()
+        for key in self.__dict__:
+            if key.startswith(cached_property.base_str):
+                del state[key]
+        return state
+
 
 class BaseNumericalModel(BaseModel):
     """

--- a/symfit/core/fit_results.py
+++ b/symfit/core/fit_results.py
@@ -69,10 +69,10 @@ class FitResults(object):
         :param item: Name of Goodness of Fit qualifier.
         :return: Goodness of Fit qualifier if present.
         """
-        if item in self.gof_qualifiers:
-            return self.gof_qualifiers[item]
-        else:
-            raise AttributeError
+        if 'gof_qualifiers' in vars(self):
+            if item in self.gof_qualifiers:
+                return self.gof_qualifiers[item]
+        raise AttributeError
 
     def stdev(self, param):
         """

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -195,6 +195,11 @@ class cached_property(property):
 
     Does not allow setting of the attribute.
     """
+    base_str = '_cached'
+    def __init__(self, *args, **kwargs):
+        super(cached_property, self).__init__(*args, **kwargs)
+        self.cache_attr = '{}_{}'.format(self.base_str, self.fget.__name__)
+
     def __get__(self, obj, objtype=None):
         """
         In case of a first call, this will call the decorated function and
@@ -205,22 +210,20 @@ class cached_property(property):
         :param objtype:
         :return: Output of the first call to the decorated function.
         """
-        cache_attr = '_{}'.format(self.fget.__name__)
         try:
-            return getattr(obj, cache_attr)
+            return getattr(obj, self.cache_attr)
         except AttributeError:
             # Call the wrapped function with the obj instance as argument
-            setattr(obj, cache_attr, self.fget(obj))
-            return getattr(obj, cache_attr)
+            setattr(obj, self.cache_attr, self.fget(obj))
+            return getattr(obj, self.cache_attr)
 
     def __delete__(self, obj):
         """
         Calling delete on the attribute will delete the cache.
         :param obj: parent object.
         """
-        cache_attr = '_{}'.format(self.fget.__name__)
         try:
-            delattr(obj, cache_attr)
+            delattr(obj, self.cache_attr)
         except AttributeError:
             pass
 

--- a/tests/test_fit_result.py
+++ b/tests/test_fit_result.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function
 import unittest
-import warnings
+import pickle
 import sympy
 import types
 from collections import OrderedDict
@@ -129,6 +129,21 @@ class TestFitResults(unittest.TestCase):
     def test_objective_included(self):
         """"The objective used should be included in the results."""
         return NotImplementedError()
+
+    def test_pickle(self):
+        xdata = np.linspace(1, 10, 10)
+        ydata = 3 * xdata ** 2
+
+        a = Parameter('a')  # 3.1, min=2.5, max=3.5
+        b = Parameter('b')
+        x = Variable('x')
+        y = Variable('y')
+        new = {y: a * x ** b}
+
+        fit = Fit(new, x=xdata, y=ydata)
+        fit_result = fit.execute()
+        new_result = pickle.loads(pickle.dumps(fit_result))
+        self.assertEqual(fit_result.__dict__.keys(), new_result.__dict__.keys())
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 import unittest
 from collections import OrderedDict
+import pickle
 
 import numpy as np
 
@@ -199,6 +200,30 @@ class TestModel(unittest.TestCase):
         self.assertAlmostEqual(fit_result.stdev(a), flat_result.stdev(a))
         self.assertAlmostEqual(fit_result.stdev(b), flat_result.stdev(b))
         self.assertAlmostEqual(fit_result.r_squared, flat_result.r_squared)
+
+    def test_pickle(self):
+        """
+        Make sure models can be pickled are preserved when pickling
+        """
+        xdata = np.linspace(1, 10, 10)
+        ydata = 3 * xdata ** 2
+
+        a, b = parameters('a, b')
+        x, y = variables('x, y')
+        model = Model({y: a * x ** b})
+        # We fit to make sure cached properties are activated
+        fit = Fit(model, x=xdata, y=ydata)
+        fit.execute()
+
+        new_model = pickle.loads(pickle.dumps(model))
+        # We fit to make sure cached properties are activated
+        fit = Fit(new_model, x=xdata, y=ydata)
+        fit.execute()
+
+        # We only check for keys, since the lambda functions will make the test
+        # fail since they are at a different address
+        self.assertEqual(new_model.__dict__.keys(), model.__dict__.keys())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -205,7 +205,7 @@ class TestSupport(unittest.TestCase):
             # Cache does not exist before f is called
             a._f
         self.assertEqual(a.f, 2)
-        self.assertTrue(hasattr(a, '_f'))
+        self.assertTrue(hasattr(a, '{}_f'.format(cached_property.base_str)))
         del a.f
         # check that deletion was successful
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
FitResults turned out not to loadable after pickle, because of a wrongful implementation of __getattr__.

Additionally, models where no longer pickalable because of the cached lambda functions. This adresses these issues, and tests have been added.