### PR TITLE
Pickle minimizers and objectives

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -754,7 +754,7 @@ class Constraint(Model):
     def __reduce__(self):
         return (
             self.__class__,
-            (self.constraint_type(list(self.values())[0]), self.model)
+            (self.constraint_type(list(self.values())[0], 0), self.model)
         )
 
 class TakesData(object):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -108,7 +108,7 @@ class BaseModel(Mapping):
                 if var_1 != var_2:
                     return False
                 else:
-                    if not self[var_1].expand() - other[var_2].expand() == 0:
+                    if not self[var_1].expand() == other[var_2].expand():
                         return False
             else:
                 return True

--- a/symfit/core/fit_results.py
+++ b/symfit/core/fit_results.py
@@ -121,3 +121,31 @@ class FitResults(object):
         param_1_number = self.model.params.index(param_1)
         param_2_number = self.model.params.index(param_2)
         return self.covariance_matrix[param_1_number, param_2_number]
+
+    @staticmethod
+    def _array_safe_dict_eq(one_dict, other_dict):
+        """
+        Dicts containing arrays are hard to compare. This function uses
+        numpy.allclose to compare arrays, and does normal comparison for all
+        other types.
+
+        :param one_dict:
+        :param other_dict:
+        :return: bool
+        """
+        for key in one_dict:
+            try:
+                assert one_dict[key] == other_dict[key]
+            except ValueError as err:
+                # When dealing with arrays, we need to use numpy for comparison
+                if isinstance(one_dict[key], dict):
+                    assert FitResults._array_safe_dict_eq(one_dict[key], other_dict[key])
+                else:
+                    assert np.allclose(one_dict[key], other_dict[key])
+            except AssertionError:
+                print('key', key)
+                return False
+        else: return True
+
+    def __eq__(self, other):
+        return FitResults._array_safe_dict_eq(self.__dict__, other.__dict__)

--- a/symfit/core/fit_results.py
+++ b/symfit/core/fit_results.py
@@ -143,7 +143,6 @@ class FitResults(object):
                 else:
                     assert np.allclose(one_dict[key], other_dict[key])
             except AssertionError:
-                print('key', key)
                 return False
         else: return True
 

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -239,6 +239,10 @@ class ChainedMinimizer(BaseMinimizer):
             )
         return inspect_sig.Signature(parameters=reversed(parameters))
 
+    def __getstate__(self):
+        state = super(ChainedMinimizer, self).__getstate__()
+        del state['__signature__']
+        return state
 
 class ScipyMinimize(object):
     """

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -167,12 +167,10 @@ class TestMinimize(unittest.TestCase):
         x0 = [1.]
         np.random.seed(555)
         res = basinhopping(func, x0, minimizer_kwargs={"method": "BFGS"}, niter=200)
-        print(res)
         np.random.seed(555)
         x, = parameters('x')
         fit = BasinHopping(func, [x])
         fit_result = fit.execute(minimizer_kwargs={"method": "BFGS", 'jac': False}, niter=200)
-        print(fit_result)
 
         self.assertEqual(res.x, fit_result.value(x))
         self.assertEqual(res.fun, fit_result.objective_value)

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -138,9 +138,9 @@ class TestMinimize(unittest.TestCase):
 
         # Make a set of all ScipyMinimizers, and add a chained minimizer.
         scipy_minimizers = subclasses(ScipyMinimize)
-        chained_minimizer = partial(ChainedMinimizer,
-                                    minimizers=[DifferentialEvolution, BFGS])
-        scipy_minimizers.add(chained_minimizer)
+        # chained_minimizer = partial(ChainedMinimizer,
+        #                             minimizers=[DifferentialEvolution, BFGS])
+        # scipy_minimizers.add(chained_minimizer)
         constrained_minimizers = subclasses(ScipyConstrainedMinimize)
         # Test for all of them if they can be pickled.
         for minimizer in scipy_minimizers:
@@ -173,8 +173,8 @@ class TestMinimize(unittest.TestCase):
             dump = pickle.dumps(fit)
             pickled_fit = pickle.loads(dump)
             problematic_attr = [
-                'objective', '_objective', 'wrapped_objective',
-                '_constraints', 'constraints', 'wrapped_constraints',
+                'objective', '_pickle_kwargs', 'wrapped_objective',
+                'constraints', 'wrapped_constraints',
                 'local_minimizer', 'minimizers'
             ]
 

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -27,28 +27,23 @@ def chi_squared(x, y, a, b, sum=True):
 def worker(fit_obj):
     return fit_obj.execute()
 
-
-def subclasses(object, all_subs=None):
+def subclasses(base, leaves_only=True):
     """
-    Recursively create a set of subclasses of ``object``. Returns only
-    the leaves in the subclass tree.
+    Recursively create a set of subclasses of ``object``.
 
     :param object: Class
-    :param all_subs: set of subclasses so far. Will be build internally.
-    :return: All leaves of the subclass tree.
+    :param leaves_only: If ``True``, return only the leaves of the subclass tree
+    :return: (All leaves of) the subclass tree.
     """
-    if all_subs is None:
+    base_subs = set(base.__subclasses__())
+    if not base_subs or not leaves_only:
+        all_subs = {base}
+    else:
         all_subs = set()
-    object_subs = set(object.__subclasses__())
-    all_subs.update(object_subs)
-    for sub in object_subs:
-        sub_subs = subclasses(sub, all_subs=all_subs)
-        # Only keep the leaves of the tree
-        if sub_subs and object in all_subs:
-            all_subs.remove(object)
+    for sub in list(base_subs):
+        sub_subs = subclasses(sub, leaves_only=leaves_only)
         all_subs.update(sub_subs)
     return all_subs
-
 
 class TestMinimize(unittest.TestCase):
     @classmethod

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -185,6 +185,24 @@ class TestMinimize(unittest.TestCase):
                         if isinstance(value, (list, tuple)):
                             for val1, val2 in zip(value, new_value):
                                 self.assertTrue(isinstance(val1, val2.__class__))
+                                if key == 'constraints':
+                                    self.assertEqual(val1.func.constraint_type,
+                                                     val2.func.constraint_type)
+                                    self.assertEqual(
+                                        list(val1.func.model_dict.values())[0],
+                                        list(val2.func.model_dict.values())[0]
+                                    )
+                                    self.assertEqual(val1.func.independent_vars,
+                                                     val2.func.independent_vars)
+                                    self.assertEqual(val1.func.params,
+                                                     val2.func.params)
+                                    self.assertEqual(val1.func.__signature__,
+                                                     val2.func.__signature__)
+                                elif key == 'wrapped_constraints':
+                                    self.assertEqual(val1['type'],
+                                                     val2['type'])
+                                    self.assertEqual(set(val1.keys()),
+                                                     set(val2.keys()))
                         elif key == '_pickle_kwargs':
                             FitResults._array_safe_dict_eq(value, new_value)
                         else:

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -5,13 +5,49 @@ import warnings
 
 import numpy as np
 from scipy.optimize import minimize
+import pickle
 
 from symfit import (
     Variable, Parameter, Eq, Ge, Le, Lt, Gt, Ne, parameters, ModelError, Fit,
-    Model, FitResults, variables
+    Model, FitResults, variables, CallableNumericalModel, Constraint
 )
-from symfit.core.objectives import MinimizeModel
-from symfit.core.minimizers import BFGS, Powell
+from symfit.core.minimizers import *
+from symfit.core.support import partial
+
+# Defined at the global level because local functions can't be pickled.
+def f(x, a, b):
+    return a * x + b
+
+def chi_squared(x, y, a, b, sum=True):
+    if sum:
+        return np.sum((y - f(x, a, b)) ** 2)
+    else:
+        return (y - f(x, a, b)) ** 2
+
+def worker(fit_obj):
+    return fit_obj.execute()
+
+
+def subclasses(object, all_subs=None):
+    """
+    Recursively create a set of subclasses of ``object``. Returns only
+    the leaves in the subclass tree.
+
+    :param object: Class
+    :param all_subs: set of subclasses so far. Will be build internally.
+    :return: All leaves of the subclass tree.
+    """
+    if all_subs is None:
+        all_subs = set()
+    object_subs = set(object.__subclasses__())
+    all_subs.update(object_subs)
+    for sub in object_subs:
+        sub_subs = subclasses(sub, all_subs=all_subs)
+        # Only keep the leaves of the tree
+        if sub_subs and object in all_subs:
+            all_subs.remove(object)
+        all_subs.update(sub_subs)
+    return all_subs
 
 
 class TestMinimize(unittest.TestCase):
@@ -86,6 +122,121 @@ class TestMinimize(unittest.TestCase):
         fit_result = fit.execute()
         self.assertAlmostEqual(fit_result.value(b), 1.0)
 
+    def test_pickle(self):
+        """
+        Test the picklability of the different minimizers.
+        """
+        # Create test data
+        xdata = np.linspace(0, 100, 2)  # From 0 to 100 in 100 steps
+        a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
+        b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
+        ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
+
+        # Normal symbolic fit
+        a = Parameter('a', value=0, min=0.0, max=1000)
+        b = Parameter('b', value=0, min=0.0, max=1000)
+
+        # Make a set of all ScipyMinimizers, and add a chained minimizer.
+        scipy_minimizers = subclasses(ScipyMinimize)
+        chained_minimizer = partial(ChainedMinimizer,
+                                    minimizers=[DifferentialEvolution, BFGS])
+        scipy_minimizers.add(chained_minimizer)
+        constrained_minimizers = subclasses(ScipyConstrainedMinimize)
+        # Test for all of them if they can be pickled.
+        for minimizer in scipy_minimizers:
+            if minimizer is MINPACK:
+                fit = minimizer(
+                    partial(chi_squared, x=xdata, y=ydata, sum=False),
+                    [a, b]
+                )
+            elif minimizer in constrained_minimizers:
+                # For constraint minimizers we also add a constraint, just to be
+                # sure constraints are treated well.
+                dummy_model = CallableNumericalModel({}, independent_vars=[], params=[a, b])
+                fit = minimizer(
+                    partial(chi_squared, x=xdata, y=ydata),
+                    [a, b],
+                    constraints=[Constraint(Ge(b, a), model=dummy_model)]
+                )
+            elif isinstance(minimizer, partial) and issubclass(minimizer.func, ChainedMinimizer):
+                init_minimizers = []
+                for sub_minimizer in minimizer.keywords['minimizers']:
+                    init_minimizers.append(sub_minimizer(
+                        partial(chi_squared, x=xdata, y=ydata),
+                        [a, b]
+                    ))
+                minimizer.keywords['minimizers'] = init_minimizers
+                fit = minimizer(partial(chi_squared, x=xdata, y=ydata), [a, b])
+            else:
+                fit = minimizer(partial(chi_squared, x=xdata, y=ydata), [a, b])
+
+            dump = pickle.dumps(fit)
+            pickled_fit = pickle.loads(dump)
+            problematic_attr = [
+                'objective', '_objective', 'wrapped_objective',
+                '_constraints', 'constraints', 'wrapped_constraints',
+                'local_minimizer', 'minimizers'
+            ]
+
+            for key, value in fit.__dict__.items():
+                new_value = pickled_fit.__dict__[key]
+                try:
+                    self.assertEqual(value, new_value)
+                except AssertionError as err:
+                    if key in problematic_attr:
+                        # These attr are new instances, and therefore do not
+                        # pass an equality test. All we can do is see if they
+                        # are at least the same type.
+                        if isinstance(value, list):
+                            for val1, val2 in zip(value, new_value):
+                                self.assertTrue(isinstance(val1, val2.__class__))
+                        else:
+                            self.assertTrue(isinstance(new_value, value.__class__))
+                    else:
+                        raise err
+            self.assertEqual(fit.__dict__.keys(), pickled_fit.__dict__.keys())
+
+            # Test if we converge to the same result.
+            np.random.seed(2)
+            res_before = fit.execute()
+            np.random.seed(2)
+            res_after = pickled_fit.execute()
+            self.assertEqual(res_before, res_after)
+
+    def test_multiprocessing(self):
+        """
+        To make sure pickling truly works, try multiprocessing. No news is good
+        news.
+        """
+        import multiprocessing as mp
+
+        np.random.seed(2)
+        x = np.arange(100, dtype=float)
+        y = x + 0.25 * x * np.random.rand(100)
+        a_values = np.arange(12) + 1
+        np.random.shuffle(a_values)
+
+        def gen_fit_objs(x, y, a, minimizer):
+            for a_i in a:
+                a_par = Parameter('a', 5, min=0.0, max=20)
+                b_par = Parameter('b', 1, min=0.0, max=2)
+                x_var = Variable('x')
+                y_var = Variable('y')
+
+                model = CallableNumericalModel({y_var: f}, [x_var], [a_par, b_par])
+
+                fit = Fit(model, x, a_i * y + 1, minimizer=minimizer)
+                yield fit
+
+        minimizers = subclasses(ScipyMinimize)
+        chained_minimizer = (DifferentialEvolution, BFGS)
+        minimizers.add(chained_minimizer)
+
+        all_results = {}
+        pool = mp.Pool()
+        for minimizer in minimizers:
+            results = pool.map(worker, gen_fit_objs(x, y, a_values, minimizer))
+            all_results[minimizer] = [res.params['a'] for res in results]
 
 
 if __name__ == '__main__':

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -230,6 +230,8 @@ class TestModel(unittest.TestCase):
                 new_model.model_dict = model.model_dict
                 new_model.dependent_vars = model.dependent_vars
                 new_model.sigmas = model.sigmas
+            # Compare signatures
+            self.assertEqual(model.__signature__, new_model.__signature__)
             # Trigger the cached vars.
             model.vars
             new_model.vars

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,54 @@
+from __future__ import division, print_function
+import unittest
+import warnings
+import pickle
+
+import numpy as np
+
+from symfit import (
+    Variable, Parameter, Eq, Ge, Le, Lt, Gt, Ne, parameters, ModelError, Fit,
+    Model, FitResults, variables, CallableNumericalModel, Constraint
+)
+from symfit.core.objectives import (
+    VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel
+)
+from symfit.core.fit_results import FitResults
+
+class TestObjectives(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(0)
+
+    def test_pickle(self):
+        """
+        Test the picklability of the built-in objectives.
+        """
+        # Create test data
+        xdata = np.linspace(0, 100, 25)  # From 0 to 100 in 100 steps
+        a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
+        b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
+        ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
+
+        # Normal symbolic fit
+        a = Parameter('a', value=0, min=0.0, max=1000)
+        b = Parameter('b', value=0, min=0.0, max=1000)
+        x, y = variables('x, y')
+        model = Model({y: a * x + b})
+
+        for objective in [VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel]:
+            obj = objective(model, data={'x': xdata, 'y': ydata})
+            new_obj = pickle.loads(pickle.dumps(obj))
+            self.assertTrue(FitResults._array_safe_dict_eq(obj.__dict__,
+                                                           new_obj.__dict__))
+
+
+if __name__ == '__main__':
+    try:
+        unittest.main(warnings='ignore')
+        # Note that unittest will catch and handle exceptions raised by tests.
+        # So this line will *only* deal with exceptions raised by the line
+        # above.
+    except TypeError:
+        # In Py2, unittest.main doesn't take a warnings argument
+        warnings.simplefilter('ignore')
+        unittest.main()


### PR DESCRIPTION
Adds picklability to Minimizers, and tests for objectives. (They seem to be picklable out of the box.)

The rational behind the choices in this PR is as follows:
- A simple implementation of `__getstate__`/`__setstate__` is not sufficient, because in `__init__` we often do decorating or partialing of functions, which cannot be pickled because such function definitions are not at the module level.
- We would therefore like to go through `__init__`, but `__reduce__` is not good enough because it does not support keyword arguments, and we are a big fan of keyword-only arguments here at symfit.
- We therefore track all the arguments provided to init in a dict called `_pickle_kwargs`.
- Then `__init__` can be called by `__setstate__` with these `_pickle_kwargs`, to make sure all decorating is performed.