### PR TITLE
__reduce__ replaced by __setstate__ for models.

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -215,6 +215,7 @@ class BaseModel(Mapping):
         # Remove cached_property values from the state, they need to be
         # re-calculated after pickle.
         state = self.__dict__.copy()
+        del state['__signature__']
         for key in self.__dict__:
             if key.startswith(cached_property.base_str):
                 del state[key]
@@ -222,6 +223,7 @@ class BaseModel(Mapping):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        self.__signature__ = self._make_signature()
 
 
 class BaseNumericalModel(BaseModel):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -220,8 +220,8 @@ class BaseModel(Mapping):
                 del state[key]
         return state
 
-    def __reduce__(self):
-        return (self.__class__, (self.model_dict,))
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
 
 class BaseNumericalModel(BaseModel):
@@ -276,12 +276,6 @@ class BaseNumericalModel(BaseModel):
     def shared_parameters(self):
         raise NotImplementedError(
             'Shared parameters can not be inferred for {}'.format(self.__class__.__name__)
-        )
-
-    def __reduce__(self):
-        return (
-            self.__class__,
-            (self.model_dict, self.independent_vars, self.params)
         )
 
 
@@ -751,11 +745,6 @@ class Constraint(Model):
         ]
         return inspect_sig.Signature(parameters=parameters)
 
-    def __reduce__(self):
-        return (
-            self.__class__,
-            (self.constraint_type(list(self.values())[0], 0), self.model)
-        )
 
 class TakesData(object):
     """
@@ -1842,17 +1831,6 @@ class ODEModel(CallableModel):
         self.sigmas = {var: Variable(name='sigma_{}'.format(var.name)) for var in self.dependent_vars}
 
         self.__signature__ = self._make_signature()
-
-    def __reduce__(self):
-        if self.lsoda_kwargs:
-            from pickle import PicklingError
-            raise PicklingError(
-                '{} with lsoda_kwargs can not be pickled.'.format(self.__class__)
-            )
-        return (
-            self.__class__,
-            tuple([self.model_dict, self.initial] + list(self.lsoda_args))
-        )
 
     def __str__(self):
         """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -212,37 +212,17 @@ class TestModel(unittest.TestCase):
         num_model = CallableNumericalModel(
             {y: a * x ** b}, independent_vars=[x], params=[a, b]
         )
-        # Test if lsoda args are pickled too
-        ode_model = ODEModel({D(y, x): a * x + b}, {x: 0.0}, 3, 4)
+        # Test if lsoda args and kwargs are pickled too
+        ode_model = ODEModel({D(y, x): a * x + b}, {x: 0.0}, 3, 4, some_kwarg=True)
         for model in [exact_model, constraint, num_model, ode_model]:
             new_model = pickle.loads(pickle.dumps(model))
-            if isinstance(model, Constraint):
-                # For constraints the dependent var names are generated. Every
-                # field dependent on this has to be updated.
-                self.assertEqual(
-                    len(model.dependent_vars), len(new_model.dependent_vars)
-                )
-                self.assertEqual(
-                    len(model.sigmas), len(new_model.sigmas)
-                )
-                for expr1, expr2 in zip(model.model_dict.values(), new_model.model_dict.values()):
-                    self.assertEqual(expr1, expr2)
-                new_model.model_dict = model.model_dict
-                new_model.dependent_vars = model.dependent_vars
-                new_model.sigmas = model.sigmas
             # Compare signatures
             self.assertEqual(model.__signature__, new_model.__signature__)
             # Trigger the cached vars.
             model.vars
             new_model.vars
             self.assertEqual(new_model.__dict__, model.__dict__)
-        # ODEModels with lsoda kwargs cannot be pickled, python doesn't
-        # support kwargs pickling :(
-        ode_model = ODEModel({D(y, x): a * x + b}, {x: 0.0},
-                             3, 4, some_kwarg=True
-                             )
-        with self.assertRaises(pickle.PicklingError):
-            pickle.dumps(ode_model)
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Turns out this is possible afterall, and way better. I must've had some conflicts in my code which made it seem like `__setstate__` was not the solution. It is.