### PR TITLE
Remove wrapping from Objectives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,10 +38,10 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    'sympy': ('http://docs.sympy.org/latest', None),
+    'sympy': ('https://docs.sympy.org/latest', None),
     'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-    'matplotlib': ('http://matplotlib.org', None)
+    'matplotlib': ('https://matplotlib.org', None)
 }
 
 nitpick_ignore = [
@@ -50,6 +50,7 @@ nitpick_ignore = [
     ('py:mod', 'scipy'),
     ('py:mod', 'matplotlib'),
     ('py:mod', 'sympy'),
+    ('py:class', 'sympy.core.relational.Relational'),
     ('py:func', 'symfit.core.leastsqbound.leastsqbound')
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy >= 1.12
 scipy >= 1.0
-sympy <= 1.1.1
+sympy >= 1.2
 funcsigs; python_version < '3.0'
 functools32; python_version < '3.0'

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -115,3 +115,9 @@ class Variable(Argument):
     # Variable index to be assigned to generated nameless variables
     _argument_name = 'var'
     __slots__ = ()
+
+    def _numpycode(self, printer):
+        return printer.doprint(self.name)
+
+    _lambdacode = _numpycode
+    _sympystr = _numpycode

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -240,7 +240,6 @@ class BaseNumericalModel(BaseModel):
     """
     def __init__(self, model, independent_vars, params):
         """
-
         :param model: dict of ``callable``, where dependent variables are the
             keys. If instead of a dict a (sequence of) ``callable`` is provided,
             it will be turned into a dict automatically.
@@ -294,7 +293,8 @@ class BaseCallableModel(BaseModel):
     """
     def eval_components(self, *args, **kwargs):
         """
-        :return: lambda functions of each of the components in model_dict, to be used in numerical calculation.
+        :return: lambda functions of each of the components in model_dict, to be
+            used in numerical calculation.
         """
         return [expr(*args, **kwargs) for expr in self.numerical_components]
 
@@ -455,7 +455,7 @@ class CallableModel(BaseCallableModel):
     def numerical_components(self):
         """
         :return: lambda functions of each of the analytical components in
-        model_dict, to be used in numerical calculation.
+            model_dict, to be used in numerical calculation.
         """
         return [sympy_to_py(expr, self.independent_vars, self.params) for expr in self.values()]
 
@@ -479,9 +479,10 @@ class Model(CallableModel):
     @property
     def jacobian(self):
         """
-        :return: Jacobian 'Matrix' filled with the symbolic expressions for all the partial derivatives.
-          Partial derivatives are of the components of the function with respect to the Parameter's,
-          not the independent Variable's.
+        :return: Jacobian 'Matrix' filled with the symbolic expressions for all
+            the partial derivatives. Partial derivatives are of the components
+            of the function with respect to the Parameter's, not the independent
+            Variable's.
         """
         return [[sympy.diff(expr, param) for param in self.params] for expr in self.values()]
 
@@ -495,7 +496,8 @@ class Model(CallableModel):
     @property
     def chi(self):
         """
-        :return: Symbolic Square root of :math:`\\chi^2`. Required for MINPACK optimization only. Denoted as :math:`\\sqrt(\\chi^2)`
+        :return: Symbolic Square root of :math:`\\chi^2`. Required for MINPACK
+            optimization only. Denoted as :math:`\\sqrt(\\chi^2)`
         """
         return sympy.sqrt(self.chi_squared)
 
@@ -503,7 +505,8 @@ class Model(CallableModel):
     def chi_jacobian(self):
         """
         Return a symbolic jacobian of the :math:`\\sqrt(\\chi^2)` function.
-        Vector of derivatives w.r.t. each parameter. Not a Matrix but a vector! This is because that's what leastsq needs.
+        Vector of derivatives w.r.t. each parameter. Not a Matrix but a vector!
+        This is because that's what leastsq needs.
         """
         jac = []
         for param in self.params:
@@ -535,28 +538,32 @@ class Model(CallableModel):
     @cached_property
     def numerical_jacobian(self):
         """
-        :return: lambda functions of the jacobian matrix of the function, which can be used in numerical optimization.
+        :return: lambda functions of the jacobian matrix of the function, which
+            can be used in numerical optimization.
         """
         return [[sympy_to_py(partial_dv, self.independent_vars, self.params) for partial_dv in row] for row in self.jacobian]
 
     @cached_property
     def numerical_chi_squared(self):
         """
-        :return: lambda function of the ``.chi_squared`` method, to be used in numerical optimisation.
+        :return: lambda function of the ``.chi_squared`` method, to be used in
+            numerical optimisation.
         """
         return sympy_to_py(self.chi_squared, self.vars, self.params)
 
     @cached_property
     def numerical_chi(self):
         """
-        :return: lambda function of the ``.chi`` method, to be used in MINPACK optimisation.
+        :return: lambda function of the ``.chi`` method, to be used in MINPACK
+            optimisation.
         """
         return sympy_to_py(self.chi, self.vars, self.params)
 
     @cached_property
     def numerical_chi_jacobian(self):
         """
-        :return: lambda functions of the jacobian of the ``.chi`` method, which can be used in numerical optimization.
+        :return: lambda functions of the jacobian of the ``.chi`` method, which
+            can be used in numerical optimization.
         """
         return [sympy_to_py(component, self.vars, self.params) for component in self.chi_jacobian]
 
@@ -986,6 +993,7 @@ class HasCovarianceMatrix(TakesData):
     def _reduced_residual_ss(self, best_fit_params, flatten=False):
         """
         Calculate the residual Sum of Squares divided by the d.o.f..
+
         :param best_fit_params: ``dict`` of best fit parameters as given by .best_fit_params()
         :param flatten: when `True`, return the total sum of squares (SS).
             If `False`, return the componentwise SS.
@@ -1237,12 +1245,14 @@ class LinearLeastSquares(BaseFit):
         Execute an analytical (Linear) Least Squares Fit. This object works by symbolically
         solving when :math:`\\nabla \\chi^2 = 0`.
 
-        To perform this task the expression of :math:`\\nabla \\chi^2` is determined, ignoring that
-        :math:`\\chi^2` involves summing over all terms. Then the sum is performed by substituting
-        the variables by their respective data and summing all terms, while leaving the parameters
+        To perform this task the expression of :math:`\\nabla \\chi^2` is
+        determined, ignoring that :math:`\\chi^2` involves summing over all
+        terms. Then the sum is performed by substituting the variables by their
+        respective data and summing all terms, while leaving the parameters
         symbolic.
 
-        The resulting system of equations is then easily solved with ``sympy.solve``.
+        The resulting system of equations is then easily solved with
+        ``sympy.solve``.
 
         :return: ``FitResult``
         """
@@ -1491,7 +1501,8 @@ class Fit(HasCovarianceMatrix):
         Takes the user provided constraints and converts them to a list of
         :class:`~symfit.core.fit.Constraint` objects.
 
-        :param constraints: iterable of :class:`sympy.Relation` objects.
+        :param constraints: iterable of :class:`~sympy.core.relational.Relation`
+            objects.
         :return: list of :class:`~symfit.core.fit.Constraint` objects.
         """
         con_models = []

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -712,6 +712,11 @@ class Constraint(Model):
             else:
                 raise TypeError('The model argument must be of type Model.')
             super(Constraint, self).__init__(constraint.lhs - constraint.rhs)
+
+            # Update the signature to accept all vars and parms of the model
+            self.independent_vars = self.model.vars
+            self.params = self.model.params
+            self.__signature__ = self._make_signature()
         else:
             raise TypeError('Constraints have to be initiated with a subclass of sympy.Relational')
 
@@ -745,14 +750,6 @@ class Constraint(Model):
         :return: lambda functions of the jacobian matrix of the function, which can be used in numerical optimization.
         """
         return [[sympy_to_py(partial_dv, self.model.vars, self.model.params) for partial_dv in row] for row in self.jacobian]
-
-    def _make_signature(self):
-        # Handle args and kwargs according to the allowed names.
-        parameters = [  # Note that these are inspect_sig.Parameter's, not symfit parameters!
-            inspect_sig.Parameter(arg.name, inspect_sig.Parameter.POSITIONAL_OR_KEYWORD)
-                for arg in self.model.vars + self.model.params
-        ]
-        return inspect_sig.Signature(parameters=parameters)
 
 
 class TakesData(object):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -282,6 +282,9 @@ class BaseNumericalModel(BaseModel):
 
     @property
     def shared_parameters(self):
+        """
+        BaseNumericalModel's cannot infer if parameters are shared.
+        """
         raise NotImplementedError(
             'Shared parameters can not be inferred for {}'.format(self.__class__.__name__)
         )

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -193,6 +193,13 @@ class BaseModel(Mapping):
             else:
                 return False
 
+    @property
+    def unfixed_params(self):
+        """
+        :return: ordered list of the subset of variable params
+        """
+        return [p for p in self.params if not p.fixed]
+
     def __str__(self):
         """
         Printable representation of a Mapping model.
@@ -1477,7 +1484,7 @@ class Fit(HasCovarianceMatrix):
             # Minimizers are agnostic about data, they just know about
             # objective functions. So we partial away the data at this point.
             minimizer_options['constraints'] = [
-                partial(constraint, **key2str(self.data))
+                MinimizeModel(constraint, data=self.data)
                 for constraint in self.constraints
             ]
         return minimizer(self.objective, self.model.params, **minimizer_options)

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -194,7 +194,7 @@ class BaseModel(Mapping):
                 return False
 
     @property
-    def unfixed_params(self):
+    def free_params(self):
         """
         :return: ordered list of the subset of variable params
         """

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -377,9 +377,9 @@ class ScipyConstrainedMinimize(ScipyMinimize, ConstrainedMinimizer):
         Returns all constraints in a scipy compatible format.
 
         :param constraints: List of either MinimizeModel instances (this is what
-            is provided by :mod:`~symfit.core.fit.Fit`),
-            :mod:`~symfit.core.fit.Constraint`, or
-            :mod:`~sympy.core.relational.Rel`.
+          is provided by :class:`~symfit.core.fit.Fit`),
+          :class:`~symfit.core.fit.Constraint`, or
+          :class:`sympy.core.relational.Relational`.
         :return: dict of scipy compatible statements.
         """
         cons = []

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -378,7 +378,7 @@ class ScipyConstrainedMinimize(ScipyMinimize, ConstrainedMinimizer):
 
         :param constraints: List of either MinimizeModel instances (this is what
             is provided by :mod:`~symfit.core.fit.Fit`),
-            :mod:`~symfit.core.fit.Constraints`, or :mod:`~sympy.Rel`.
+            :mod:`~symfit.core.fit.Constraint`, or :mod:`~sympy.Rel`.
         :return: dict of scipy compatible statements.
         """
         cons = []

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -378,7 +378,8 @@ class ScipyConstrainedMinimize(ScipyMinimize, ConstrainedMinimizer):
 
         :param constraints: List of either MinimizeModel instances (this is what
             is provided by :mod:`~symfit.core.fit.Fit`),
-            :mod:`~symfit.core.fit.Constraint`, or :mod:`~sympy.Rel`.
+            :mod:`~symfit.core.fit.Constraint`, or
+            :mod:`~sympy.core.relational.Rel`.
         :return: dict of scipy compatible statements.
         """
         cons = []

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -253,25 +253,6 @@ class ScipyMinimize(object):
         self.jacobian = None
         self.wrapped_jacobian = None
         super(ScipyMinimize, self).__init__(*args, **kwargs)
-        self.wrapped_objective = self.list2kwargs(self.objective)
-
-    def list2kwargs(self, func):
-        """
-        Given an objective function `func`, make sure it is always called via
-        keyword arguments with the relevant parameter names.
-
-        :param func: Function to be wrapped to keyword only calls.
-        :return: wrapped function
-        """
-        if func is None:
-            return None
-        # Because scipy calls the objective with a list of parameters as
-        # guesses, we use 'values' instead of '*values'.
-        @wraps(func)
-        def wrapped_func(values):
-            parameters = key2str(dict(zip(self.params, values)))
-            return np.array(func(**parameters))
-        return wrapped_func
 
     @keywordonly(tol=1e-9)
     def execute(self, bounds=None, jacobian=None, constraints=None, **minimize_options):
@@ -353,7 +334,6 @@ class ScipyGradientMinimize(ScipyMinimize, GradientMinimizer):
     """
     def __init__(self, *args, **kwargs):
         super(ScipyGradientMinimize, self).__init__(*args, **kwargs)
-        self.wrapped_jacobian = self.list2kwargs(self.wrapped_jacobian)
 
     def execute(self, **minimize_options):
         return super(ScipyGradientMinimize, self).execute(jacobian=self.wrapped_jacobian, **minimize_options)

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -68,14 +68,15 @@ class BaseObjective(object):
         """
         # zip will stop when the shortest of the two is exhausted
         parameters.update(dict(zip(self.model.unfixed_params, ordered_parameters)))
-        parameters.update(self.model_kwargs)
+        parameters.update(self.invariant_kwargs)
         return self.model(**key2str(parameters))
 
     @cached_property
-    def model_kwargs(self):
+    def invariant_kwargs(self):
         """
-        Prepares the other kwargs to ``self.model`` which are not provided by
-        the minimizers. This means fixed parameters and data, matching the
+        Prepares the invariant kwargs to ``self.model`` which are not provided
+        by the minimizers, and are the same for every iteration of the
+        minimization. This means fixed parameters and data, matching the
         signature of ``self.model``.
         """
         kwargs = {p: p.value for p in self.model.params
@@ -111,7 +112,7 @@ class GradientObjective(BaseObjective):
         :return: evaluated jacobian
         """
         parameters.update(dict(zip(self.model.unfixed_params, ordered_parameters)))
-        parameters.update(self.model_kwargs)
+        parameters.update(self.invariant_kwargs)
         return self.model.eval_jacobian(**key2str(parameters))
 
 

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -67,7 +67,7 @@ class BaseObjective(object):
         :return: evaluated model.
         """
         # zip will stop when the shortest of the two is exhausted
-        parameters.update(dict(zip(self.model.unfixed_params, ordered_parameters)))
+        parameters.update(dict(zip(self.model.free_params, ordered_parameters)))
         parameters.update(self.invariant_kwargs)
         return self.model(**key2str(parameters))
 
@@ -80,7 +80,7 @@ class BaseObjective(object):
         signature of ``self.model``.
         """
         kwargs = {p: p.value for p in self.model.params
-                     if p not in self.model.unfixed_params}
+                  if p not in self.model.free_params}
         data_by_name = key2str(self.data)
         kwargs.update(
             {p: data_by_name[p] for p in
@@ -111,7 +111,7 @@ class GradientObjective(BaseObjective):
         :param parameters: parameters as keyword arguments.
         :return: evaluated jacobian
         """
-        parameters.update(dict(zip(self.model.unfixed_params, ordered_parameters)))
+        parameters.update(dict(zip(self.model.free_params, ordered_parameters)))
         parameters.update(self.invariant_kwargs)
         return self.model.eval_jacobian(**key2str(parameters))
 

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -93,7 +93,7 @@ class BaseObjective(object):
         Clear cached properties. Should preferably be called after every
         minimization precedure to clean the pallette.
         """
-        del self.model_kwargs
+        del self.invariant_kwargs
 
 
 @add_metaclass(abc.ABCMeta)

--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -1,0 +1,43 @@
+from sympy.printing.pycode import NumPyPrinter
+from sympy.printing.codeprinter import CodePrinter
+
+#########################################################
+# Monkeypatch the printer until this is merged upstream #
+#########################################################
+
+class DontDeleteMe(object):
+    def __init__(self, default_value):
+        self.dont_delete = default_value
+        self.default_value = default_value
+
+    def __get__(self, instance, owner):
+        return self.dont_delete
+
+    def __set__(self, instance, value):
+        self.dont_delete = value
+
+    def __delete__(self, instance):
+        self.dont_delete = self.default_value
+
+CodePrinter._not_supported = DontDeleteMe(set())
+CodePrinter._number_symbols = DontDeleteMe(set())
+
+#########################################################
+# End of monkeypatch                                    #
+#########################################################
+
+class SymfitNumPyPrinter(NumPyPrinter):
+    """
+    Our own NumpyPrinter subclass, in case we need to print certain numpy
+    features which are not yet supported in SymPy.
+    """
+    def _print_DiracDelta(self, expr):
+        """
+        Replaces a DiracDelta(x) by np.inf if x == 0, and 0 otherwise. This is
+        wrong, but the only thing we can do by the time we are printing. To
+        prevent mistakes, integrate before printing.
+        """
+        return "{0}({1}, [{1} == 0 , {1} != 0], [{2}, 0])".format(
+                                        self._module_format('numpy.piecewise'),
+                                        self._print(expr.args[0]),
+                                        self._module_format('numpy.inf'))

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -17,6 +17,7 @@ from sympy import symbols
 from sympy.core.expr import Expr
 
 from symfit.core.argument import Parameter, Variable
+from symfit.core.printing import SymfitNumPyPrinter
 
 if sys.version_info >= (3,0):
     import inspect as inspect_sig
@@ -88,7 +89,7 @@ def sympy_to_py(func, vars, params):
     :return: lambda function to be used for numerical evaluation of the model. Ordering of the arguments will be vars
         first, then params.
     """
-    return lambdify((vars + params), func, modules='numpy', dummify=False)
+    return lambdify((vars + params), func, printer=SymfitNumPyPrinter, dummify=False)
 
 def sympy_to_scipy(func, vars, params):
     """

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -9,7 +9,8 @@ from symfit import (
 )
 from symfit.distributions import Gaussian
 from symfit.core.minimizers import SLSQP, MINPACK
-from symfit.core.support import partial
+from symfit.core.support import key2str
+from symfit.core.objectives import MinimizeModel
 
 
 class TestConstrained(unittest.TestCase):
@@ -567,27 +568,37 @@ class TestConstrained(unittest.TestCase):
                   constraints=constraints, minimizer=SLSQP)
         fit_result_slsqp = fit.execute()
         # The data and fixed parameters should be partialed away.
-        partialed_kwargs = {
+        objective_kwargs = {
+            phi2.name: phi2.value,
+            phi1.name: phi1.value,
+            x.name: xdata,
+        }
+        constraint_kwargs = {
             phi2.name: phi2.value,
             phi1.name: phi1.value,
             x.name: xdata,
             y.name: ydata,
             fit.model.sigmas[y].name: np.ones_like(ydata)
         }
-        for constraint in fit.minimizer.constraints:
-            self.assertIsInstance(constraint, partial)
-            self.assertIsInstance(constraint.func, Constraint)
-            self.assertTupleEqual(constraint.args, tuple())
+        for index, constraint in enumerate(fit.minimizer.constraints):
+            self.assertIsInstance(constraint, MinimizeModel)
+            self.assertEqual(constraint.model, fit.constraints[index])
+            self.assertEqual(constraint.data, fit.data)
+            self.assertEqual(constraint.data, fit.objective.data)
+
+            # Data should be the same memory location so they can share state.
+            self.assertEqual(id(fit.objective.data),
+                             id(constraint.data))
 
             # Test if the data and fixed params have been partialed away
-            self.assertEqual(len(partialed_kwargs), len(constraint.keywords))
-            for key, value in constraint.keywords.items():
-                self.assertTrue(key in partialed_kwargs)
-                np.testing.assert_equal(partialed_kwargs[key], value)
+            self.assertEqual(key2str(constraint.model_kwargs).keys(),
+                             constraint_kwargs.keys())
+            self.assertEqual(key2str(fit.objective.model_kwargs).keys(),
+                             objective_kwargs.keys())
 
         # Compare the shapes. The constraint shape should now be the same as
         # that of the objective
-        obj_val = fit.minimizer.wrapped_objective(fit.minimizer.initial_guesses)
+        obj_val = fit.minimizer.objective(fit.minimizer.initial_guesses)
         obj_jac = fit.minimizer.wrapped_jacobian(fit.minimizer.initial_guesses)
         with self.assertRaises(TypeError):
             len(obj_val)  # scalars don't have lengths
@@ -595,18 +606,20 @@ class TestConstrained(unittest.TestCase):
 
         for index, constraint in enumerate(fit.minimizer.wrapped_constraints):
             self.assertEqual(constraint['type'], 'ineq')
-            self.assertEqual(len(constraint['args']), 1)
-            self.assertIsInstance(constraint['args'][0], partial)
+            self.assertTrue('args' not in constraint)
             self.assertTrue(callable(constraint['fun']))
             self.assertTrue(callable(constraint['jac']))
 
             # The argument should be the partialed Constraint object
-            self.assertEqual(constraint['args'][0], fit.minimizer.constraints[index])
+            self.assertEqual(constraint['fun'], fit.minimizer.constraints[index])
+            self.assertIsInstance(constraint['fun'], MinimizeModel)
+            self.assertTrue('jac' in constraint)
 
             # Test the shapes
-            cons_val = constraint['fun'](fit.minimizer.initial_guesses, constraint['args'][0])
-            cons_jac = constraint['jac'](fit.minimizer.initial_guesses, constraint['args'][0])
-            self.assertEqual(obj_val.shape, cons_val.shape)
+            cons_val = constraint['fun'](fit.minimizer.initial_guesses)
+            cons_jac = constraint['jac'](fit.minimizer.initial_guesses)
+            with self.assertRaises(TypeError):
+                len(cons_val)  # scalars don't have lengths
             self.assertEqual(obj_jac.shape, cons_jac.shape)
             self.assertEqual(obj_jac.shape, (2,))
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -81,10 +81,16 @@ class TestConstrained(unittest.TestCase):
         b_2.value = 1
         y0.value = 10
 
+        eval_jac = model.eval_jacobian(x_1=xdata1, x_2=xdata2, a_1=101.3,
+                                       b_1=0.5, a_2=56.3, b_2=1.1111, y0=10.8)
+        self.assertEqual(len(eval_jac), 2)
+        for comp in eval_jac:
+            self.assertEqual(len(comp), len(model.params))
+
         sigma_y = np.concatenate((np.ones(20), [2., 4., 5, 7, 3]))
 
         fit = Fit(model, x_1=xdata[0], x_2=xdata[1],
-                                               y_1=ydata[0], y_2=ydata[1], sigma_y_2=sigma_y)
+                  y_1=ydata[0], y_2=ydata[1], sigma_y_2=sigma_y)
         fit_result = fit.execute()
 
         # fit_curves = model(x_1=xdata[0], x_2=xdata[1], **fit_result.params)
@@ -618,8 +624,8 @@ class TestConstrained(unittest.TestCase):
             # Test the shapes
             cons_val = constraint['fun'](fit.minimizer.initial_guesses)
             cons_jac = constraint['jac'](fit.minimizer.initial_guesses)
-            with self.assertRaises(TypeError):
-                len(cons_val)  # scalars don't have lengths
+            self.assertEqual(cons_val.shape, (1,))
+            self.assertIsInstance(cons_val[0], float)
             self.assertEqual(obj_jac.shape, cons_jac.shape)
             self.assertEqual(obj_jac.shape, (2,))
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -591,9 +591,9 @@ class TestConstrained(unittest.TestCase):
                              id(constraint.data))
 
             # Test if the data and fixed params have been partialed away
-            self.assertEqual(key2str(constraint.model_kwargs).keys(),
+            self.assertEqual(key2str(constraint.invariant_kwargs).keys(),
                              constraint_kwargs.keys())
-            self.assertEqual(key2str(fit.objective.model_kwargs).keys(),
+            self.assertEqual(key2str(fit.objective.invariant_kwargs).keys(),
                              objective_kwargs.keys())
 
         # Compare the shapes. The constraint shape should now be the same as

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -147,6 +147,18 @@ class FiniteDifferenceTests(unittest.TestCase):
                                     a_1=101.3, b_1=0.5, a_2=56.3, b_2=1.1111, y0=10.8)
         approx = model.finite_difference(x_1=xdata1, x_2=xdata2,
                                          a_1=101.3, b_1=0.5, a_2=56.3, b_2=1.1111, y0=10.8)
+        # First axis is the number of components
+        self.assertEqual(len(exact), 2)
+        self.assertEqual(len(approx), 2)
+
+        # Second axis is the number of parameters, same for all components
+        for exact_comp, approx_comp, xdata in zip(exact, approx, [xdata1, xdata2]):
+            self.assertEqual(len(exact_comp), len(model.params))
+            self.assertEqual(len(approx_comp), len(model.params))
+            for exact_elem, approx_elem in zip(exact_comp, approx_comp):
+                self.assertEqual(exact_elem.shape, xdata.shape)
+                self.assertEqual(approx_elem.shape, xdata.shape)
+
         self._assert_equal(exact, approx, rtol=1e-4)
 
         model = sf.Model({

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -553,6 +553,19 @@ class Tests(unittest.TestCase):
 
         model = Model({a_i: 2 * a + 3 * b, b_i: 5 * b, c_i: 7 * c})
         self.assertEqual([[2, 3, 0], [0, 5, 0], [0, 0, 7]], model.jacobian)
+    
+    def test_hessian_matrix(self):
+        """
+        The Hessian matrix of a model should be a 3D list (matrix) containing
+        all the 2nd partial derivatives.
+        """
+        a, b, c = parameters('a, b, c')
+        a_i, b_i, c_i = variables('a_i, b_i, c_i')
+
+        model = Model({a_i: 2 * a**2 + 3 * b, b_i: 5 * b**2, c_i: 7 * c*b})
+        self.assertEqual([[[4, 0, 0], [0, 0, 0], [0, 0, 0]], 
+                          [[0, 0, 0], [0, 10, 0], [0, 0, 0]],
+                          [[0, 0, 0], [0, 0, 7], [0, 7, 0]]], model.hessian)
 
     def test_likelihood_fitting_exponential(self):
         """

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -122,7 +122,7 @@ class TestMinimize(unittest.TestCase):
         Test the picklability of the different minimizers.
         """
         # Create test data
-        xdata = np.linspace(0, 100, 2)  # From 0 to 100 in 100 steps
+        xdata = np.linspace(0, 100, 100)  # From 0 to 100 in 100 steps
         a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
         b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
         ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
@@ -130,41 +130,26 @@ class TestMinimize(unittest.TestCase):
         # Normal symbolic fit
         a = Parameter('a', value=0, min=0.0, max=1000)
         b = Parameter('b', value=0, min=0.0, max=1000)
+        x, y = variables('x, y')
 
         # Make a set of all ScipyMinimizers, and add a chained minimizer.
-        scipy_minimizers = subclasses(ScipyMinimize)
-        chained_minimizer = partial(ChainedMinimizer,
-                                    minimizers=[DifferentialEvolution, BFGS])
-        scipy_minimizers.add(chained_minimizer)
+        scipy_minimizers = list(subclasses(ScipyMinimize))
+        chained_minimizer = (DifferentialEvolution, BFGS)
+        scipy_minimizers.append(chained_minimizer)
         constrained_minimizers = subclasses(ScipyConstrainedMinimize)
         # Test for all of them if they can be pickled.
         for minimizer in scipy_minimizers:
-            if minimizer is MINPACK:
-                fit = minimizer(
-                    partial(chi_squared, x=xdata, y=ydata, sum=False),
-                    [a, b]
-                )
-            elif minimizer in constrained_minimizers:
-                # For constraint minimizers we also add a constraint, just to be
-                # sure constraints are treated well.
-                dummy_model = CallableNumericalModel({}, independent_vars=[], params=[a, b])
-                fit = minimizer(
-                    partial(chi_squared, x=xdata, y=ydata),
-                    [a, b],
-                    constraints=[Ge(b, a)]
-                )
-            elif isinstance(minimizer, partial) and issubclass(minimizer.func, ChainedMinimizer):
-                init_minimizers = []
-                for sub_minimizer in minimizer.keywords['minimizers']:
-                    init_minimizers.append(sub_minimizer(
-                        partial(chi_squared, x=xdata, y=ydata),
-                        [a, b]
-                    ))
-                minimizer.keywords['minimizers'] = init_minimizers
-                fit = minimizer(partial(chi_squared, x=xdata, y=ydata), [a, b])
+            if minimizer in constrained_minimizers:
+                constraints = [Ge(b, a)]
             else:
-                fit = minimizer(partial(chi_squared, x=xdata, y=ydata), [a, b])
-
+                constraints = []
+            model = CallableNumericalModel(
+                {y: f},
+                independent_vars=[x], params=[a, b]
+            )
+            fit = Fit(model, x=xdata, y=ydata, minimizer=minimizer,
+                      constraints=constraints)
+            fit = fit.minimizer  # Just check if the minimizer pickles
             dump = pickle.dumps(fit)
             pickled_fit = pickle.loads(dump)
             problematic_attr = [
@@ -186,18 +171,18 @@ class TestMinimize(unittest.TestCase):
                             for val1, val2 in zip(value, new_value):
                                 self.assertTrue(isinstance(val1, val2.__class__))
                                 if key == 'constraints':
-                                    self.assertEqual(val1.func.constraint_type,
-                                                     val2.func.constraint_type)
+                                    self.assertEqual(val1.model.constraint_type,
+                                                     val2.model.constraint_type)
                                     self.assertEqual(
-                                        list(val1.func.model_dict.values())[0],
-                                        list(val2.func.model_dict.values())[0]
+                                        list(val1.model.model_dict.values())[0],
+                                        list(val2.model.model_dict.values())[0]
                                     )
-                                    self.assertEqual(val1.func.independent_vars,
-                                                     val2.func.independent_vars)
-                                    self.assertEqual(val1.func.params,
-                                                     val2.func.params)
-                                    self.assertEqual(val1.func.__signature__,
-                                                     val2.func.__signature__)
+                                    self.assertEqual(val1.model.independent_vars,
+                                                     val2.model.independent_vars)
+                                    self.assertEqual(val1.model.params,
+                                                     val2.model.params)
+                                    self.assertEqual(val1.model.__signature__,
+                                                     val2.model.__signature__)
                                 elif key == 'wrapped_constraints':
                                     self.assertEqual(val1['type'],
                                                      val2['type'])

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -7,12 +7,27 @@ import numpy as np
 
 from symfit import (
     Variable, Parameter, Eq, Ge, Le, Lt, Gt, Ne, parameters, ModelError, Fit,
-    Model, FitResults, variables, CallableNumericalModel, Constraint
+    Model, FitResults, variables, CallableNumericalModel, Constraint, Idx,
+    IndexedBase, symbols, Sum, log
 )
 from symfit.core.objectives import (
     VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel
 )
 from symfit.core.fit_results import FitResults
+from symfit.core.printing import SymfitNumPyPrinter
+from symfit.distributions import Exp
+
+# Overwrite the way Sum is printed by numpy just while testing. Is not
+# general enough to be moved to SymfitNumPyPrinter, but has to be used
+# in this test. This way of sommung complety ignores the summation indices and
+# the dimensions, and instead just flattens everything to a scalar. Only used
+# in this test to build the analytical equivalents of our LeastSquares
+# and LogLikelihood
+def _print_Sum(self, expr):
+    return "%s(%s)" % (self._module_format('numpy.sum'),
+                       self._print(expr.function))
+SymfitNumPyPrinter._print_Sum = _print_Sum
+
 
 class TestObjectives(unittest.TestCase):
     @classmethod
@@ -40,6 +55,134 @@ class TestObjectives(unittest.TestCase):
             new_obj = pickle.loads(pickle.dumps(obj))
             self.assertTrue(FitResults._array_safe_dict_eq(obj.__dict__,
                                                            new_obj.__dict__))
+
+    def test_LeastSquares(self):
+        """
+        Tests if the LeastSquares objective gives the right shapes of output by
+        comparing with its analytical equivalent.
+        """
+        i = Idx('i', 100)
+        x, y = symbols('x, y', cls=Variable)
+        X2 = symbols('X2', cls=Variable)
+        a, b = parameters('a, b')
+
+        model = Model({y: a * x**2 + b * x})
+        xdata = np.linspace(0, 10, 100)
+        ydata = model(x=xdata, a=5, b=2).y + np.random.normal(0, 5, xdata.shape)
+
+        # Construct a LeastSquares objective and its analytical equivalent
+        chi2_numerical = LeastSquares(model, data={
+            x: xdata, y: ydata, model.sigmas[y]: np.ones_like(xdata)
+        })
+        chi2_exact = Model(
+            {X2: Sum(((a * x ** 2 + b * x) - y) ** 2, i)})
+
+        eval_exact = chi2_exact(x=xdata, y=ydata, a=2, b=3)
+        jac_exact = chi2_exact.eval_jacobian(x=xdata, y=ydata, a=2, b=3)
+        hess_exact = chi2_exact.eval_hessian(x=xdata, y=ydata, a=2, b=3)
+        eval_numerical = chi2_numerical(x=xdata, a=2, b=3)
+        jac_numerical = chi2_numerical.eval_jacobian(x=xdata, a=2, b=3)
+        hess_numerical = chi2_numerical.eval_hessian(x=xdata, a=2, b=3)
+
+        # Test model jacobian and hessian shape
+        self.assertEqual(model(x=xdata, a=2, b=3)[0].shape, ydata.shape)
+        self.assertEqual(model.eval_jacobian(x=xdata, a=2, b=3)[0].shape,
+                         (2, 100))
+        # Hessian no longer depends on the data, so its a scalar in the last dim
+        self.assertEqual(model.eval_hessian(x=xdata, a=2, b=3)[0].shape,
+                         (2, 2, 1))
+        # Test exact chi2 shape
+        self.assertEqual(eval_exact[0].shape, (1,))
+        self.assertEqual(jac_exact[0].shape, (2, 1))
+        self.assertEqual(hess_exact[0].shape, (2, 2, 1))
+
+        # Test if these two models have the same call, jacobian, and hessian
+        self.assertAlmostEqual(eval_exact[0], eval_numerical)
+        self.assertIsInstance(eval_numerical, float)
+        self.assertIsInstance(eval_exact[0][0], float)
+        np.testing.assert_almost_equal(np.squeeze(jac_exact[0], axis=-1),
+                                       jac_numerical)
+        self.assertIsInstance(jac_numerical, np.ndarray)
+        np.testing.assert_almost_equal(np.squeeze(hess_exact[0], axis=-1),
+                                       hess_numerical)
+        self.assertIsInstance(hess_numerical, np.ndarray)
+
+        fit = Fit(chi2_exact, x=xdata, y=ydata, objective=MinimizeModel)
+        fit_exact_result = fit.execute()
+        fit = Fit(model, x=xdata, y=ydata)
+        fit_num_result = fit.execute()
+        self.assertEqual(fit_exact_result.value(a), fit_num_result.value(a))
+        self.assertEqual(fit_exact_result.value(b), fit_num_result.value(b))
+        # TODO: uncomment the next line. Currently doesn't work because the
+        # analytical model does not have a cov matrix for some reason.
+        # self.assertEqual(fit_exact_result, fit_num_result)
+
+
+    def test_LogLikelihood(self):
+        """
+        Tests if the LeastSquares objective gives the right shapes of output by
+        comparing with its analytical equivalent.
+        """
+        # TODO: update these tests to use indexed variables in the future
+        a, b = parameters('a, b')
+        i = Idx('i', 100)
+        x, y = variables('x, y')
+        pdf = Exp(x, 1 / a) * Exp(x, b)
+
+        np.random.seed(10)
+        xdata = np.random.exponential(3.5, 100)
+
+        # We use minus loglikelihood for the model, because the objective was
+        # designed to find the maximum when used with a *minimizer*, so it has
+        # opposite sign. Also test MinimizeModel at the same time.
+        logL_model = Model({y: pdf})
+        logL_exact = Model({y: - Sum(log(pdf), i)})
+        logL_numerical = LogLikelihood(logL_model, {x: xdata, y: None})
+        logL_minmodel = MinimizeModel(logL_exact, data={x: xdata, y: None})
+
+        # Test model jacobian and hessian shape
+        eval_exact = logL_exact(x=xdata, a=2, b=3)
+        jac_exact = logL_exact.eval_jacobian(x=xdata, a=2, b=3)
+        hess_exact = logL_exact.eval_hessian(x=xdata, a=2, b=3)
+        eval_minimizemodel = logL_minmodel(a=2, b=3)
+        jac_minimizemodel = logL_minmodel.eval_jacobian(a=2, b=3)
+        hess_minimizemodel = logL_minmodel.eval_hessian(a=2, b=3)
+        eval_numerical = logL_numerical(a=2, b=3)
+        jac_numerical = logL_numerical.eval_jacobian(a=2, b=3)
+        hess_numerical = logL_numerical.eval_hessian(a=2, b=3)
+
+        # TODO: These shapes should not have the ones! This is due to the current
+        # convention that scalars should be returned as a 1d array by Model's.
+        self.assertEqual(eval_exact[0].shape, (1,))
+        self.assertEqual(jac_exact[0].shape, (2, 1))
+        self.assertEqual(hess_exact[0].shape, (2, 2, 1))
+        # Test if identical to MinimizeModel
+        np.testing.assert_almost_equal(eval_exact[0], eval_minimizemodel)
+        np.testing.assert_almost_equal(jac_exact[0], jac_minimizemodel)
+        np.testing.assert_almost_equal(hess_exact[0], hess_minimizemodel)
+
+        # Test if these two models have the same call, jacobian, and hessian.
+        # Since models always have components as their first dimension, we have
+        # to slice that away.
+        self.assertAlmostEqual(eval_exact.y, eval_numerical)
+        self.assertIsInstance(eval_numerical, float)
+        self.assertIsInstance(eval_exact.y[0], float)
+        np.testing.assert_almost_equal(np.squeeze(jac_exact[0], axis=-1),
+                                       jac_numerical)
+        self.assertIsInstance(jac_numerical, np.ndarray)
+        np.testing.assert_almost_equal(np.squeeze(hess_exact[0], axis=-1),
+                                       hess_numerical)
+        self.assertIsInstance(hess_numerical, np.ndarray)
+
+        fit = Fit(logL_exact, x=xdata, y=None, objective=MinimizeModel)
+        fit_exact_result = fit.execute()
+        fit = Fit(logL_model, x=xdata, objective=LogLikelihood)
+        fit_num_result = fit.execute()
+        self.assertEqual(fit_exact_result.value(a), fit_num_result.value(a))
+        self.assertEqual(fit_exact_result.value(b), fit_num_result.value(b))
+        # TODO: uncomment the next line. Currently doesn't work because the
+        # analytical model does not have a cov matrix for some reason.
+        # self.assertEqual(fit_exact_result, fit_num_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR makes a couple of big changes to the objective/minimizer dynamic which I think will make it easier to add certain features in the future.

- Constraints are now no longer partialed with all the data before being fed to the minimizers by `Fit`, but instead turned into a `MinimizeModel` objective, since that's conceptually what they do. This the flow of information a lot clearer, especially for ScipyMinimize subclasses.
This also takes a significant step towards fixing #154, in principle clearing the way for normal Models to be used as constraints.
- `BaseObjective` subclasses now have an `invariant_kwargs` cached property, which returns all the data and fixed parameters demanded by its `.model`'s signature. This prepares the way to #194, creating a place where invariant quantities can be found and stored. Also, this means fixed parameters no longer have to partialed away, as they can be seen as invariants.
- More controversial, I think that the `list2kwargs` decorator should be removed, and instead `BaseObjective` subclasses should just have an extra argument, `ordered_parameters`, from which the parameters provided can be turned into kwargs internally. The reason for this is that it makes the minimizer code a lot cleaner and easier to debug due to way less partialing and wrapping, and it doesn't take anything away from the API. Scipy, still our main supplier of minimizers, always wants to use such an argument, and if in the future we have a minimizer which doesn't then the preferred `**parameters` are still there.
- This removal of `list2kwargs` does create one new problem: when using a custum objective and feeding it to e.g. the SLSQP class, the signature of such a model has to be the scipy one, not the prefered keyword argument one. This can be solved I believe, by realizing that the new `CallableNumericalModel` was created exactly for this purpose: to give a sensible interface between a custom callable and the `symfit` API. Therefore, I suggest that `BaseMinimizer` should check if it was provided with something which is not an instance of `BaseObjective`, and if not we transform that into `MinimizeModel(CallableNumericalModel(custom_objective))` instead.