### PR TITLE
Hessian and many other steps towards 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy >= 1.12
 scipy >= 1.0
-sympy <= 1.1.1
+sympy >= 1.3
 funcsigs; python_version < '3.0'
 functools32; python_version < '3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy >= 1.12
 scipy >= 1.0
-sympy >= 1.3
+sympy >= 1.2
 funcsigs; python_version < '3.0'
 functools32; python_version < '3.0'

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -115,3 +115,9 @@ class Variable(Argument):
     # Variable index to be assigned to generated nameless variables
     _argument_name = 'var'
     __slots__ = ()
+
+    def _numpycode(self, printer):
+        return printer.doprint(self.name)
+
+    _lambdacode = _numpycode
+    _sympystr = _numpycode

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -299,7 +299,7 @@ class BaseCallableModel(BaseModel):
         :return: lambda functions of each of the components in model_dict, to be
             used in numerical calculation.
         """
-        return [expr(*args, **kwargs) for expr in self.numerical_components]
+        return [np.atleast_1d(expr(*args, **kwargs)) for expr in self.numerical_components]
 
     @abstractmethod
     def numerical_components(self):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -994,9 +994,8 @@ class HasCovarianceMatrix(TakesData):
         if isinstance(self.objective, LogLikelihood):
             # Loglikelihood is a special case that needs to be considered
             # separately, see #138
-            jac = self.objective.eval_jacobian(apply_func=lambda x: x, **key2str(best_fit_params))
-            cov_matrix_inv = np.tensordot(jac, jac, (range(1, jac.ndim), range(1, jac.ndim)))
-            cov_mat = np.linalg.inv(cov_matrix_inv)
+            hess = self.objective.eval_hessian(**key2str(best_fit_params))
+            cov_mat = np.linalg.inv(hess)
             return cov_mat
         try:
             if len(set(arr.shape for arr in self.sigma_data.values())) == 1:

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -986,13 +986,13 @@ class HasCovarianceMatrix(TakesData):
             return np.array(
                 [[float('nan') for p in self.model.params] for p in self.model.params]
             )
-        if isinstance(self.objective, LogLikelihood):
-            # Loglikelihood is a special case that needs to be considered
-            # separately, see #138
-            hess = self.objective.eval_hessian(**key2str(best_fit_params))
-            cov_mat = np.linalg.inv(hess)
-            return cov_mat
         try:
+            if isinstance(self.objective, LogLikelihood):
+                # Loglikelihood is a special case that needs to be considered
+                # separately, see #138
+                hess = self.objective.eval_hessian(**key2str(best_fit_params))
+                cov_mat = np.linalg.inv(hess)
+                return cov_mat
             if len(set(arr.shape for arr in self.sigma_data.values())) == 1:
                 # Shapes of all sigma data identical
                 return self._cov_mat_equal_lenghts(best_fit_params=best_fit_params)
@@ -1068,6 +1068,8 @@ class HasCovarianceMatrix(TakesData):
         mask = [data is not None for data in self.dependent_data.values()]
         jac = jac[mask]
         W = W[mask]
+        if jac.shape[0] == 0:
+            return None
 
         # Order jacobian as param, component, datapoint
         jac = np.swapaxes(jac, 0, 1)

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -612,10 +612,10 @@ class Model(CallableModel):
             shapes = [np.atleast_1d(diff).shape for diff in comp]
             # Funny key so that higher dimensional data > lower dimensional
             # data
-            largest = max(shapes, key=lambda s: (len(s), *s))
+            largest = max(shapes, key=lambda s: [len(s)]+list(s))
             ones = np.ones(largest, dtype=float)
             data = np.array([ones * diff for diff in comp])
-            jac[idx] = data.reshape((len(comp), *largest))
+            jac[idx] = data.reshape([len(comp)] + list(largest))
         return jac
 
     def eval_hessian(self, *args, **kwargs):
@@ -633,11 +633,10 @@ class Model(CallableModel):
             shapes = [np.atleast_1d(d2).shape for d1 in comp for d2 in d1]
             # Funny key so that higher dimensional data > lower dimensional
             # data
-            largest = max(shapes,
-                          key=lambda s: (len(s), *s))
+            largest = max(shapes, key=lambda s: [len(s)]+list(s))
             ones = np.ones(largest, dtype=float)
             data = np.array([ones * d2 for d1 in comp for d2 in d1])
-            hess[idx] = data.reshape((len(comp), len(comp), *largest))
+            hess[idx] = data.reshape([len(comp), len(comp)] + list(largest))
         return hess
 
 

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -50,18 +50,21 @@ class BaseMinimizer(object):
         :param objective_type:
         :return:
         """
-        if isinstance(func, BaseObjective):
+        if isinstance(func, BaseObjective) or (hasattr(func, '__self__') and
+                                               isinstance(func.__self__, BaseObjective)):
+            # The latter condition is added to make sure .eval_jacobian methods
+            # are still considered correct, and not doubly wrapped.
             return func
         else:
             # Minimize the provided custom objective instead. This why want to
             # minimize a CallableNumericalModel, thats what they are for.
             from .fit import CallableNumericalModel
-            return objective_type(
-                CallableNumericalModel(func,
-                                       params=self.parameters,
-                                       independent_vars=[]),
-                data={}
-            )
+            model = CallableNumericalModel(func,
+                                           params=self.parameters,
+                                           independent_vars=[])
+            return objective_type(model,
+                                  data={y: None for y in model.dependent_vars})
+
     @abc.abstractmethod
     def execute(self, **options):
         """

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -545,6 +545,7 @@ class BasinHopping(ScipyMinimize, BaseMinimizer):
         """
         self.local_minimizer = kwargs.pop('local_minimizer')
         super(BasinHopping, self).__init__(*args, **kwargs)
+        self._pickle_kwargs['local_minimizer'] = self.local_minimizer
 
         type_error_msg = 'Currently only subclasses of ScipyMinimize are ' \
                          'supported, since `scipy.optimize.basinhopping` uses ' \

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -215,16 +215,17 @@ class LeastSquares(GradientObjective):
         )
         result = [0.0 for _ in self.model.params]
 
-        for ans, var, row in zip(evaluated_func, self.model, evaluated_jac):
-            dep_data = self.dependent_data[var]
+        for var, f, row in zip(self.model, evaluated_func, evaluated_jac):
+            y = self.dependent_data[var]
             sigma_var = self.model.sigmas[var]
-            if dep_data is not None:
+            if y is not None:
                 sigma = self.sigma_data[sigma_var]  # Should be changed with #41
-                for index, component in enumerate(row):
-                    result[index] += np.sum(
-                        component * ((dep_data - ans) / sigma ** 2)
+                for index, df in enumerate(row):
+                    # df = \nabla_p_i f
+                    result[index] -= 2 * np.sum(
+                        df * ((y - f) / sigma ** 2)
                     )
-        return - np.array(result).T
+        return np.array(result).T
 
 
 class LogLikelihood(GradientObjective):

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -91,6 +91,10 @@ class BaseObjective(object):
                 if dep_data.shape == component.shape:
                     shaped_result.append(component)
                 else:
+                    # Add extra dimensions to the component if needed.
+                    dim_diff = len(dep_data.shape) - len(component.shape[param_level:])
+                    for _ in range(dim_diff):
+                        component = np.expand_dims(component, -1)
                     # Let numpy deal with all the broadcasting
                     shape = param_level * [n_params] + list(dep_data.shape)
                     shaped_result.append(np.broadcast_to(component, shape))
@@ -303,7 +307,7 @@ class LeastSquares(HessianObjective):
                 p1 = hess_comp * ((y - f) / sigma**2)[np.newaxis, np.newaxis, ...]
                 # Outer product
                 p2 = np.einsum('i...,j...->ij...', jac_comp, jac_comp)
-                p2 / sigma[np.newaxis, np.newaxis, ...]**2
+                p2 /= sigma[np.newaxis, np.newaxis, ...]**2
                 # We sum away everything except the matrices in the axes 0 & 1.
                 axes = tuple(range(2, len(p2.shape)))
                 result += 2 * np.sum(p2 - p1, axis=axes, keepdims=False)

--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -1,0 +1,10 @@
+from sympy.printing.pycode import NumPyPrinter
+
+class SymfitNumPyPrinter(NumPyPrinter):
+    def _print_OnesLike(self, expr):
+        return "%s(%s)" % (self._module_format('numpy.ones_like'),
+                           self._print(expr.args[0]))
+
+    def _print_ZerosLike(self, expr):
+        return "%s(%s)" % (self._module_format('numpy.zeros_like'),
+                           self._print(expr.args[0]))

--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -27,20 +27,10 @@ CodePrinter._number_symbols = DontDeleteMe(set())
 #########################################################
 
 class SymfitNumPyPrinter(NumPyPrinter):
-    def _print_OnesLike(self, expr):
-        return "%s(%s)" % (self._module_format('numpy.ones_like'),
-                           self._print(expr.args[0]))
-
-    def _print_ZerosLike(self, expr):
-        return "%s(%s)" % (self._module_format('numpy.zeros_like'),
-                           self._print(expr.args[0]))
-
-    def _print_VarOnesLikeVar(self, expr):
-        return self._print(expr.args[0])
-
-    def _print_Variable(self, expr):
-        return self._print(expr.name)
-
+    """
+    Our own NumpyPrinter subclass, in case we need to print certain numpy
+    features which are not yet supported in SymPy.
+    """
     def _print_DiracDelta(self, expr):
         """
         Replaces a DiracDelta(x) by np.inf if x == 0, and 0 otherwise. This is

--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -1,4 +1,80 @@
 from sympy.printing.pycode import NumPyPrinter
+from sympy.printing.codeprinter import CodePrinter
+
+#########################################################
+# Monkeypatch the printer until this is merged upstream #
+#########################################################
+from sympy.core import sympify
+from sympy.core.basic import Basic
+from sympy.core.compatibility import string_types
+from sympy.core.symbol import Symbol
+
+# Backwards compatibility
+from sympy.codegen.ast import Assignment
+
+def doprint(self, expr, assign_to=None):
+    """
+    Print the expression as code.
+
+    Parameters
+    ----------
+    expr : Expression
+        The expression to be printed.
+
+    assign_to : Symbol, MatrixSymbol, or string (optional)
+        If provided, the printed code will set the expression to a
+        variable with name ``assign_to``.
+    """
+    from sympy.matrices.expressions.matexpr import MatrixSymbol
+
+    if isinstance(assign_to, string_types):
+        if expr.is_Matrix:
+            assign_to = MatrixSymbol(assign_to, *expr.shape)
+        else:
+            assign_to = Symbol(assign_to)
+    elif not isinstance(assign_to, (Basic, type(None))):
+        raise TypeError("{0} cannot assign to object of type {1}".format(
+            type(self).__name__, type(assign_to)))
+
+    if assign_to:
+        expr = Assignment(assign_to, expr)
+    else:
+        # _sympify is not enough b/c it errors on iterables
+        expr = sympify(expr)
+
+    # keep a set of expressions that are not strictly translatable to Code
+    # and number constants that must be declared and initialized
+    self._not_supported = set()
+    self._number_symbols = set()
+
+    lines = self._print(expr).splitlines()
+
+    # format the output
+    if self._settings["human"]:
+        frontlines = []
+        if len(self._not_supported) > 0:
+            frontlines.append(self._get_comment(
+                "Not supported in {0}:".format(self.language)))
+            for expr in sorted(self._not_supported, key=str):
+                frontlines.append(self._get_comment(type(expr).__name__))
+        for name, value in sorted(self._number_symbols, key=str):
+            frontlines.append(self._declare_number_const(name, value))
+        lines = frontlines + lines
+        lines = self._format_code(lines)
+        result = "\n".join(lines)
+    else:
+        lines = self._format_code(lines)
+        num_syms = set([(k, self._print(v)) for k, v in self._number_symbols])
+        result = (num_syms, self._not_supported, "\n".join(lines))
+    self._not_supported = set()
+    self._number_symbols = set()
+    return result
+
+CodePrinter.doprint = doprint
+
+#########################################################
+# End of monkeypatch                                    #
+#########################################################
 
 class SymfitNumPyPrinter(NumPyPrinter):
     def _print_OnesLike(self, expr):
@@ -8,3 +84,9 @@ class SymfitNumPyPrinter(NumPyPrinter):
     def _print_ZerosLike(self, expr):
         return "%s(%s)" % (self._module_format('numpy.zeros_like'),
                            self._print(expr.args[0]))
+
+    def _print_VarOnesLikeVar(self, expr):
+        return self._print(expr.args[0])
+
+    def _print_Variable(self, expr):
+        return self._print(expr.name)

--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -4,73 +4,23 @@ from sympy.printing.codeprinter import CodePrinter
 #########################################################
 # Monkeypatch the printer until this is merged upstream #
 #########################################################
-from sympy.core import sympify
-from sympy.core.basic import Basic
-from sympy.core.compatibility import string_types
-from sympy.core.symbol import Symbol
 
-# Backwards compatibility
-from sympy.codegen.ast import Assignment
+class DontDeleteMe(object):
+    def __init__(self, default_value):
+        self.dont_delete = default_value
+        self.default_value = default_value
 
-def doprint(self, expr, assign_to=None):
-    """
-    Print the expression as code.
+    def __get__(self, instance, owner):
+        return self.dont_delete
 
-    Parameters
-    ----------
-    expr : Expression
-        The expression to be printed.
+    def __set__(self, instance, value):
+        self.dont_delete = value
 
-    assign_to : Symbol, MatrixSymbol, or string (optional)
-        If provided, the printed code will set the expression to a
-        variable with name ``assign_to``.
-    """
-    from sympy.matrices.expressions.matexpr import MatrixSymbol
+    def __delete__(self, instance):
+        self.dont_delete = self.default_value
 
-    if isinstance(assign_to, string_types):
-        if expr.is_Matrix:
-            assign_to = MatrixSymbol(assign_to, *expr.shape)
-        else:
-            assign_to = Symbol(assign_to)
-    elif not isinstance(assign_to, (Basic, type(None))):
-        raise TypeError("{0} cannot assign to object of type {1}".format(
-            type(self).__name__, type(assign_to)))
-
-    if assign_to:
-        expr = Assignment(assign_to, expr)
-    else:
-        # _sympify is not enough b/c it errors on iterables
-        expr = sympify(expr)
-
-    # keep a set of expressions that are not strictly translatable to Code
-    # and number constants that must be declared and initialized
-    self._not_supported = set()
-    self._number_symbols = set()
-
-    lines = self._print(expr).splitlines()
-
-    # format the output
-    if self._settings["human"]:
-        frontlines = []
-        if len(self._not_supported) > 0:
-            frontlines.append(self._get_comment(
-                "Not supported in {0}:".format(self.language)))
-            for expr in sorted(self._not_supported, key=str):
-                frontlines.append(self._get_comment(type(expr).__name__))
-        for name, value in sorted(self._number_symbols, key=str):
-            frontlines.append(self._declare_number_const(name, value))
-        lines = frontlines + lines
-        lines = self._format_code(lines)
-        result = "\n".join(lines)
-    else:
-        lines = self._format_code(lines)
-        num_syms = set([(k, self._print(v)) for k, v in self._number_symbols])
-        result = (num_syms, self._not_supported, "\n".join(lines))
-    self._not_supported = set()
-    self._number_symbols = set()
-    return result
-
-CodePrinter.doprint = doprint
+CodePrinter._not_supported = DontDeleteMe(set())
+CodePrinter._number_symbols = DontDeleteMe(set())
 
 #########################################################
 # End of monkeypatch                                    #

--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -90,3 +90,14 @@ class SymfitNumPyPrinter(NumPyPrinter):
 
     def _print_Variable(self, expr):
         return self._print(expr.name)
+
+    def _print_DiracDelta(self, expr):
+        """
+        Replaces a DiracDelta(x) by np.inf if x == 0, and 0 otherwise. This is
+        wrong, but the only thing we can do by the time we are printing. To
+        prevent mistakes, integrate before printing.
+        """
+        return "{0}({1}, [{1} == 0 , {1} != 0], [{2}, 0])".format(
+                                        self._module_format('numpy.piecewise'),
+                                        self._print(expr.args[0]),
+                                        self._module_format('numpy.inf'))

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -17,6 +17,7 @@ from sympy import symbols
 from sympy.core.expr import Expr
 
 from symfit.core.argument import Parameter, Variable
+from symfit.core.printing import SymfitNumPyPrinter
 
 if sys.version_info >= (3,0):
     import inspect as inspect_sig
@@ -88,7 +89,7 @@ def sympy_to_py(func, vars, params):
     :return: lambda function to be used for numerical evaluation of the model. Ordering of the arguments will be vars
         first, then params.
     """
-    return lambdify((vars + params), func, modules='numpy', dummify=False)
+    return lambdify((vars + params), func, printer=SymfitNumPyPrinter, dummify=False)
 
 def sympy_to_scipy(func, vars, params):
     """

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -81,10 +81,16 @@ class TestConstrained(unittest.TestCase):
         b_2.value = 1
         y0.value = 10
 
+        eval_jac = model.eval_jacobian(x_1=xdata1, x_2=xdata2, a_1=101.3,
+                                       b_1=0.5, a_2=56.3, b_2=1.1111, y0=10.8)
+        self.assertEqual(len(eval_jac), 2)
+        for comp in eval_jac:
+            self.assertEqual(len(comp), len(model.params))
+
         sigma_y = np.concatenate((np.ones(20), [2., 4., 5, 7, 3]))
 
         fit = Fit(model, x_1=xdata[0], x_2=xdata[1],
-                                               y_1=ydata[0], y_2=ydata[1], sigma_y_2=sigma_y)
+                  y_1=ydata[0], y_2=ydata[1], sigma_y_2=sigma_y)
         fit_result = fit.execute()
 
         # fit_curves = model(x_1=xdata[0], x_2=xdata[1], **fit_result.params)
@@ -618,8 +624,8 @@ class TestConstrained(unittest.TestCase):
             # Test the shapes
             cons_val = constraint['fun'](fit.minimizer.initial_guesses)
             cons_jac = constraint['jac'](fit.minimizer.initial_guesses)
-            with self.assertRaises(TypeError):
-                len(cons_val)  # scalars don't have lengths
+            self.assertEqual(cons_val.shape, (1,))
+            self.assertIsInstance(cons_val[0], float)
             self.assertEqual(obj_jac.shape, cons_jac.shape)
             self.assertEqual(obj_jac.shape, (2,))
 

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -147,6 +147,18 @@ class FiniteDifferenceTests(unittest.TestCase):
                                     a_1=101.3, b_1=0.5, a_2=56.3, b_2=1.1111, y0=10.8)
         approx = model.finite_difference(x_1=xdata1, x_2=xdata2,
                                          a_1=101.3, b_1=0.5, a_2=56.3, b_2=1.1111, y0=10.8)
+        # First axis is the number of components
+        self.assertEqual(len(exact), 2)
+        self.assertEqual(len(approx), 2)
+
+        # Second axis is the number of parameters, same for all components
+        for exact_comp, approx_comp, xdata in zip(exact, approx, [xdata1, xdata2]):
+            self.assertEqual(len(exact_comp), len(model.params))
+            self.assertEqual(len(approx_comp), len(model.params))
+            for exact_elem, approx_elem in zip(exact_comp, approx_comp):
+                self.assertEqual(exact_elem.shape, xdata.shape)
+                self.assertEqual(approx_elem.shape, xdata.shape)
+
         self._assert_equal(exact, approx, rtol=1e-4)
 
         model = sf.Model({

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -553,6 +553,19 @@ class Tests(unittest.TestCase):
 
         model = Model({a_i: 2 * a + 3 * b, b_i: 5 * b, c_i: 7 * c})
         self.assertEqual([[2, 3, 0], [0, 5, 0], [0, 0, 7]], model.jacobian)
+    
+    def test_hessian_matrix(self):
+        """
+        The Hessian matrix of a model should be a 3D list (matrix) containing
+        all the 2nd partial derivatives.
+        """
+        a, b, c = parameters('a, b, c')
+        a_i, b_i, c_i = variables('a_i, b_i, c_i')
+
+        model = Model({a_i: 2 * a**2 + 3 * b, b_i: 5 * b**2, c_i: 7 * c*b})
+        self.assertEqual([[[4, 0, 0], [0, 0, 0], [0, 0, 0]], 
+                          [[0, 0, 0], [0, 10, 0], [0, 0, 0]],
+                          [[0, 0, 0], [0, 0, 7], [0, 7, 0]]], model.hessian)
 
     def test_likelihood_fitting_exponential(self):
         """

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -122,7 +122,7 @@ class TestMinimize(unittest.TestCase):
         Test the picklability of the different minimizers.
         """
         # Create test data
-        xdata = np.linspace(0, 100, 2)  # From 0 to 100 in 100 steps
+        xdata = np.linspace(0, 100, 100)  # From 0 to 100 in 100 steps
         a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
         b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
         ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
@@ -130,41 +130,26 @@ class TestMinimize(unittest.TestCase):
         # Normal symbolic fit
         a = Parameter('a', value=0, min=0.0, max=1000)
         b = Parameter('b', value=0, min=0.0, max=1000)
+        x, y = variables('x, y')
 
         # Make a set of all ScipyMinimizers, and add a chained minimizer.
-        scipy_minimizers = subclasses(ScipyMinimize)
-        chained_minimizer = partial(ChainedMinimizer,
-                                    minimizers=[DifferentialEvolution, BFGS])
-        scipy_minimizers.add(chained_minimizer)
+        scipy_minimizers = list(subclasses(ScipyMinimize))
+        chained_minimizer = (DifferentialEvolution, BFGS)
+        scipy_minimizers.append(chained_minimizer)
         constrained_minimizers = subclasses(ScipyConstrainedMinimize)
         # Test for all of them if they can be pickled.
         for minimizer in scipy_minimizers:
-            if minimizer is MINPACK:
-                fit = minimizer(
-                    partial(chi_squared, x=xdata, y=ydata, sum=False),
-                    [a, b]
-                )
-            elif minimizer in constrained_minimizers:
-                # For constraint minimizers we also add a constraint, just to be
-                # sure constraints are treated well.
-                dummy_model = CallableNumericalModel({}, independent_vars=[], params=[a, b])
-                fit = minimizer(
-                    partial(chi_squared, x=xdata, y=ydata),
-                    [a, b],
-                    constraints=[Ge(b, a)]
-                )
-            elif isinstance(minimizer, partial) and issubclass(minimizer.func, ChainedMinimizer):
-                init_minimizers = []
-                for sub_minimizer in minimizer.keywords['minimizers']:
-                    init_minimizers.append(sub_minimizer(
-                        partial(chi_squared, x=xdata, y=ydata),
-                        [a, b]
-                    ))
-                minimizer.keywords['minimizers'] = init_minimizers
-                fit = minimizer(partial(chi_squared, x=xdata, y=ydata), [a, b])
+            if minimizer in constrained_minimizers:
+                constraints = [Ge(b, a)]
             else:
-                fit = minimizer(partial(chi_squared, x=xdata, y=ydata), [a, b])
-
+                constraints = []
+            model = CallableNumericalModel(
+                {y: f},
+                independent_vars=[x], params=[a, b]
+            )
+            fit = Fit(model, x=xdata, y=ydata, minimizer=minimizer,
+                      constraints=constraints)
+            fit = fit.minimizer  # Just check if the minimizer pickles
             dump = pickle.dumps(fit)
             pickled_fit = pickle.loads(dump)
             problematic_attr = [
@@ -186,18 +171,18 @@ class TestMinimize(unittest.TestCase):
                             for val1, val2 in zip(value, new_value):
                                 self.assertTrue(isinstance(val1, val2.__class__))
                                 if key == 'constraints':
-                                    self.assertEqual(val1.func.constraint_type,
-                                                     val2.func.constraint_type)
+                                    self.assertEqual(val1.model.constraint_type,
+                                                     val2.model.constraint_type)
                                     self.assertEqual(
-                                        list(val1.func.model_dict.values())[0],
-                                        list(val2.func.model_dict.values())[0]
+                                        list(val1.model.model_dict.values())[0],
+                                        list(val2.model.model_dict.values())[0]
                                     )
-                                    self.assertEqual(val1.func.independent_vars,
-                                                     val2.func.independent_vars)
-                                    self.assertEqual(val1.func.params,
-                                                     val2.func.params)
-                                    self.assertEqual(val1.func.__signature__,
-                                                     val2.func.__signature__)
+                                    self.assertEqual(val1.model.independent_vars,
+                                                     val2.model.independent_vars)
+                                    self.assertEqual(val1.model.params,
+                                                     val2.model.params)
+                                    self.assertEqual(val1.model.__signature__,
+                                                     val2.model.__signature__)
                                 elif key == 'wrapped_constraints':
                                     self.assertEqual(val1['type'],
                                                      val2['type'])

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -85,8 +85,9 @@ class TestObjectives(unittest.TestCase):
         self.assertEqual(model(x=xdata, a=2, b=3)[0].shape, ydata.shape)
         self.assertEqual(model.eval_jacobian(x=xdata, a=2, b=3)[0].shape,
                          (2, 100))
+        # Hessian no longer depends on the data, so its a scalar in the last dim
         self.assertEqual(model.eval_hessian(x=xdata, a=2, b=3)[0].shape,
-                         (2, 2, 100))
+                         (2, 2, 1))
         # Test exact chi2 shape
         self.assertEqual(eval_exact[0].shape, (1,))
         self.assertEqual(jac_exact[0].shape, (2, 1))

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -19,7 +19,10 @@ from symfit.distributions import Exp
 
 # Overwrite the way Sum is printed by numpy just while testing. Is not
 # general enough to be moved to SymfitNumPyPrinter, but has to be used
-# in this test.
+# in this test. This way of sommung complety ignores the summation indices and
+# the dimensions, and instead just flattens everything to a scalar. Only used
+# in this test to build the analytical equivalents of our LeastSquares
+# and LogLikelihood
 def _print_Sum(self, expr):
     return "%s(%s)" % (self._module_format('numpy.sum'),
                        self._print(expr.function))

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -7,12 +7,24 @@ import numpy as np
 
 from symfit import (
     Variable, Parameter, Eq, Ge, Le, Lt, Gt, Ne, parameters, ModelError, Fit,
-    Model, FitResults, variables, CallableNumericalModel, Constraint
+    Model, FitResults, variables, CallableNumericalModel, Constraint, Idx,
+    IndexedBase, symbols, Sum, log
 )
 from symfit.core.objectives import (
     VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel
 )
 from symfit.core.fit_results import FitResults
+from symfit.core.printing import SymfitNumPyPrinter
+from symfit.distributions import Exp
+
+# Overwrite the way Sum is printed by numpy just while testing. Is not
+# general enough to be moved to SymfitNumPyPrinter, but has to be used
+# in this test.
+def _print_Sum(self, expr):
+    return "%s(%s)" % (self._module_format('numpy.sum'),
+                       self._print(expr.function))
+SymfitNumPyPrinter._print_Sum = _print_Sum
+
 
 class TestObjectives(unittest.TestCase):
     @classmethod
@@ -40,6 +52,108 @@ class TestObjectives(unittest.TestCase):
             new_obj = pickle.loads(pickle.dumps(obj))
             self.assertTrue(FitResults._array_safe_dict_eq(obj.__dict__,
                                                            new_obj.__dict__))
+
+    def test_LeastSquares(self):
+        """
+        Tests if the LeastSquares objective gives the right shapes of output by
+        comparing with its analytical equivalent.
+        """
+        i = Idx('i', 100)
+        x, y = symbols('x, y', cls=Variable)
+        X2 = symbols('X2', cls=Variable)
+        a, b = parameters('a, b')
+
+        model = Model({y: a * x**2 + b * x})
+        xdata = np.linspace(0, 10, 100)
+        ydata = model(x=xdata, a=5, b=2).y
+
+        # Construct a LeastSquares objective and its analytical equivalent
+        chi2_numerical = LeastSquares(model, data={
+            x: xdata, y: ydata, model.sigmas[y]: np.ones_like(xdata)
+        })
+        chi2_exact = Model(
+            {X2: Sum(((a * x ** 2 + b * x) - y) ** 2, i)})
+
+        eval_exact = chi2_exact(x=xdata, y=ydata, a=2, b=3)
+        jac_exact = chi2_exact.eval_jacobian(x=xdata, y=ydata, a=2, b=3)
+        hess_exact = chi2_exact.eval_hessian(x=xdata, y=ydata, a=2, b=3)
+        eval_numerical = chi2_numerical(x=xdata, a=2, b=3)
+        jac_numerical = chi2_numerical.eval_jacobian(x=xdata, a=2, b=3)
+        hess_numerical = chi2_numerical.eval_hessian(x=xdata, a=2, b=3)
+        print(eval_numerical.shape, jac_numerical.shape, hess_numerical.shape)
+        # Test model jacobian and hessian shape
+        self.assertEqual(model(x=xdata, a=2, b=3)[0].shape, ydata.shape)
+        self.assertEqual(model.eval_jacobian(x=xdata, a=2, b=3)[0].shape,
+                         (2, 100))
+        self.assertEqual(model.eval_hessian(x=xdata, a=2, b=3)[0].shape,
+                         (2, 2, 100))
+        # Test exact chi2 shape
+        self.assertEqual(eval_exact[0].shape, tuple())
+        self.assertEqual(jac_exact[0].shape, (2,))
+        self.assertEqual(hess_exact[0].shape, (2, 2))
+
+        # Test if these two models have the same call, jacobian, and hessian
+        self.assertAlmostEqual(eval_exact[0], eval_numerical)
+        self.assertIsInstance(eval_numerical, float)
+        self.assertIsInstance(eval_exact[0], float)
+        np.testing.assert_almost_equal(jac_exact[0], jac_numerical)
+        self.assertIsInstance(jac_numerical, np.ndarray)
+        np.testing.assert_almost_equal(hess_exact[0], hess_numerical)
+        self.assertIsInstance(hess_numerical, np.ndarray)
+
+    def test_LogLikelihood(self):
+        """
+        Tests if the LeastSquares objective gives the right shapes of output by
+        comparing with its analytical equivalent.
+        """
+        # TODO: update these tests to use indexed variables in the future
+        a, b = parameters('a, b')
+        i = Idx('i', 100)
+        x, y = variables('x, y')
+        pdf = Exp(x, 1 / a) * Exp(x, b)
+
+        np.random.seed(10)
+        xdata = np.random.exponential(3.5, 100)
+
+        # We use minus loglikelihood for the model, because the objective was
+        # designed to find the maximum when used with a *minimizer*, so it has
+        # opposite sign. Also test MinimizeModel at the same time.
+        logL_exact = Model({y: - Sum(log(pdf), i)})
+        logL_numerical = LogLikelihood(Model({y: pdf}), {x:xdata})
+        logL_minmodel = MinimizeModel(logL_exact, data={x:xdata})
+
+        # Test model jacobian and hessian shape
+        eval_exact = logL_exact(x=xdata, a=2, b=3)
+        jac_exact = logL_exact.eval_jacobian(x=xdata, a=2, b=3)
+        hess_exact = logL_exact.eval_hessian(x=xdata, a=2, b=3)
+        eval_minimizemodel = logL_minmodel(a=2, b=3)
+        jac_minimizemodel = logL_minmodel.eval_jacobian(a=2, b=3)
+        hess_minimizemodel = logL_minmodel.eval_hessian(a=2, b=3)
+        eval_numerical = logL_minmodel(a=2, b=3)
+        jac_numerical = logL_minmodel.eval_jacobian(a=2, b=3)
+        hess_numerical = logL_minmodel.eval_hessian(a=2, b=3)
+
+        self.assertEqual(eval_exact[0].shape, tuple())
+        self.assertEqual(jac_exact[0].shape, (2,))
+        self.assertEqual(hess_exact[0].shape, (2, 2))
+        # Test if identical to MinimizeModel
+        np.testing.assert_almost_equal(eval_exact[0], eval_minimizemodel)
+        np.testing.assert_almost_equal(jac_exact[0], jac_minimizemodel)
+        np.testing.assert_almost_equal(hess_exact[0], hess_minimizemodel)
+
+        # Test if these two models have the same call, jacobian, and hessian.
+        # Since models always have components as their first dimension, we have
+        # to slice that away.
+        self.assertAlmostEqual(eval_exact.y, eval_numerical)
+        self.assertIsInstance(eval_numerical, float)
+        self.assertIsInstance(eval_exact.y, float)
+        np.testing.assert_almost_equal(
+            jac_exact[0],
+            jac_numerical
+        )
+        self.assertIsInstance(jac_numerical, np.ndarray)
+        np.testing.assert_almost_equal(hess_exact[0], hess_numerical)
+        self.assertIsInstance(hess_numerical, np.ndarray)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Starting from #195 and #196, this completes the job of adding hessians to our models and objectives in the new structure initiated with #195.

However, it became much more than just that because of the realization that Hessians quite easily destroy the shape of our models, because deriving twice wrt a parameter seriously increases the likelihood of getting 0. When this happens, we were no longer able to infer the output shape in the previous scheme.

This PR therefore radically changes the approach to shaping:
- Models can not know about the shape of the dependent data, only the objectives can. So for example, when averaging `{y: a}` with `y` a dataset and `a` just a constant, the model is unable to know the shape of the result, even-though we need an array with the same shape as `y`. This is now done in the objective in `_shape_dependent_data`, which is called on all model results before continuing.
- When the model does have vars, e.g. `{y: a * x}`, then the jacobian and hessian lose the shape information: `{D(y, a): a}` and `{D(y, a, a): 0}`. This is bad, because it destroys broadcasting when going to numpy arrays for models less trivial then this one. This PR proposes the following solution: replace `x` by `x * OnesLike(x)`, where `OnesLike` is a new sympolic object which gets printed into `np.ones_like`.
This solves the problem because of the properties of `OnesLike` and its sibling `ZerosLike` under differentiation, addition etc. In the simple example above:
```python
{y: a * x * OnesLike(x, a)}
{D(y, a): a * OnesLike(x, a)}
{D(y, a, a): ZerosLike(x, a)}
```
(all parameters have to arguments of this object because otherwise sympy recognizes that this derivative is trivially zero)

Other changes:
- Hessian is used for covariance matrix in LogLikelihood
- 

Things to be considered:
- Hessian should always be used as the covariance matrix if possible.
- Better simplification rules for OnesLike, ZerosLike and VarOnesLikeVar
- Discussion about the shapes of Jacobians and Hessians needs to be had. I think that for objectives, __call__ should return a scalar, eval_jacobian a vector, and eval_hessian a matrix. This is also the way I implemented it now. However, I feel that if you feed the symbolic equivalent to MinimizeModel, we should get the same shapes.
```python
chi2_exact = Model({X2: Sum(((a * x ** 2 + b * x) - y) ** 2, i)})
eval_exact = chi2_exact(x=xdata, y=ydata, a=2, b=3)                         # shape: (1, 1)
jac_exact = chi2_exact.eval_jacobian(x=xdata, y=ydata, a=2, b=3)  # shape: (1, 2, 1)
hess_exact = chi2_exact.eval_hessian(x=xdata, y=ydata, a=2, b=3)  # shape: (1, 2, 2, 1)
```
This first 1 is justified, it is due to the fact that models are always iterable over the components, even scalar models. But the last one should not be there I feel. This only appears because of our convention that the elements should always be at least 1d arrays, even if it is a scalar. If we get rid of this convention, the output from `MinimizeModel(chi2_exact, data={})` would be identical to that of `LeastSquares` of the same function, which is something which makes a lot of sense to me. However, I don't think `scipy` cares either way so I left it like this for now.