### PR TITLE
Chained minimizer kwargs error solved.

### DIFF
--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -1,6 +1,6 @@
 import abc
 import sys
-from collections import namedtuple, Counter
+from collections import namedtuple, Counter, OrderedDict
 
 from scipy.optimize import (
     minimize, differential_evolution, basinhopping, NonlinearConstraint
@@ -254,10 +254,15 @@ class ChainedMinimizer(BaseMinimizer):
         :return:  an instance of :class:`~symfit.core.fit_results.FitResults`.
         """
         bound_arguments = self.__signature__.bind(**minimizer_kwargs)
-        # Include default values in bound_argument object
+        # Include default values in bound_argument object.
+        # Start from a new OrderedDict to guarantee ordering.
+        arguments = OrderedDict()
         for param in self.__signature__.parameters.values():
-            if param.name not in bound_arguments.arguments:
-                bound_arguments.arguments[param.name] = param.default
+            if param.name in bound_arguments.arguments:
+                arguments[param.name] = bound_arguments.arguments[param.name]
+            else:
+                arguments[param.name] = param.default
+        bound_arguments.arguments = arguments
 
         answers = []
         next_guess = self.initial_guesses

--- a/tests/test_global_opt.py
+++ b/tests/test_global_opt.py
@@ -108,10 +108,11 @@ class TestGlobalOptGaussian(unittest.TestCase):
 
         for param in fit.minimizer.__signature__.parameters.values():
             self.assertEqual(param.kind, inspect_sig.Parameter.KEYWORD_ONLY)
-        # Make sure this ends up at the right minimizer. Due to an error it
-        # used to end up at the first BFGS and raise
-        # TypeError: minimize() got an unexpected keyword argument 'strategy'
-        fit.execute(DifferentialEvolution={'strategy': 'best1bin'})
+        # Make sure keywords end up at the right minimizer.
+        with self.assertRaises(TypeError):
+            # This is not a valid kwarg to DiffEvo, but it is to BFGS. Check if
+            # we really go by name of the Minimizer, not by order.
+            fit.execute(DifferentialEvolution={'return_all': False})
 
 
 class TestGlobalOptMexican(unittest.TestCase):

--- a/tests/test_global_opt.py
+++ b/tests/test_global_opt.py
@@ -91,14 +91,14 @@ class TestGlobalOptGaussian(unittest.TestCase):
         Test the automatic generation of the signature for ChainedMinimizer
         """
         minimizers = [
-            DifferentialEvolution, BFGS, BFGS, DifferentialEvolution, BFGS
+            BFGS, DifferentialEvolution, BFGS, DifferentialEvolution, BFGS
         ]
 
         fit = Fit(self.model, self.xx, self.yy, self.ydata,
                   minimizer=minimizers)
 
         names = [
-            'DifferentialEvolution', 'BFGS', 'BFGS_2',
+            'BFGS', 'DifferentialEvolution', 'BFGS_2',
             'DifferentialEvolution_2', 'BFGS_3'
         ]
         for name, param_name in zip(names, fit.minimizer.__signature__.parameters):
@@ -108,6 +108,11 @@ class TestGlobalOptGaussian(unittest.TestCase):
 
         for param in fit.minimizer.__signature__.parameters.values():
             self.assertEqual(param.kind, inspect_sig.Parameter.KEYWORD_ONLY)
+        # Make sure this ends up at the right minimizer. Due to an error it
+        # used to end up at the first BFGS and raise
+        # TypeError: minimize() got an unexpected keyword argument 'strategy'
+        fit.execute(DifferentialEvolution={'strategy': 'best1bin'})
+
 
 class TestGlobalOptMexican(unittest.TestCase):
     def test_mexican_hat(self):


### PR DESCRIPTION
There was an error in how ChainedMinimizer set the default values to its `signature.Paramete`r objects. Although this is the standard method as described in the python docs, this actually messes up the ordering meaning that the order can no longer be counted on.

This PR solves that problem.