### PR TITLE
Fix 214

### DIFF
--- a/symfit/contrib/interactive_guess/tests/test_interactive_fit.py
+++ b/symfit/contrib/interactive_guess/tests/test_interactive_fit.py
@@ -29,7 +29,6 @@ class Gaussian2DInteractiveGuessTest(unittest.TestCase):
         k = Parameter('k', 900)
         x0 = Parameter('x0', 1.5)
 
-        # You can NOT do this in one go. Blame Sympy. Not my fault.
         cls.k = k
         cls.x0 = x0
 
@@ -37,7 +36,6 @@ class Gaussian2DInteractiveGuessTest(unittest.TestCase):
         x_data = np.linspace(0, 2.5, 50)
         y_data = model[y](x=x_data, k=1000, x0=1)
         cls.guess = interactive_guess.InteractiveGuess(model, x=x_data, y=y_data)
-#        plt.close(cls.fit.fig)
 
     def test_number_of_sliders(self):
         self.assertEqual(len(self.guess._sliders), 2)

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -1515,6 +1515,7 @@ def r_squared(model, fit_result, data):
     x_is = [data[var] for var in model.independent_vars if var in data]
     y_bars = [np.mean(y_i) if y_i is not None else None for y_i in y_is]
     f_is = model(*x_is, **fit_result.params)._asdict()
+    # f_is also contains the evaluated interdependent_vars, skip those.
     f_is = [f_is[var] for var in model.dependent_vars]
     SS_res = np.sum([np.sum((y_i - f_i)**2) for y_i, f_i in zip(y_is, f_is) if y_i is not None])
     SS_tot = np.sum([np.sum((y_i - y_bar)**2) for y_i, y_bar in zip(y_is, y_bars) if y_i is not None])

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -1008,7 +1008,7 @@ class TakesData(object):
             ``self.model``.
         """
         parameters = self._make_parameters()
-        parameters = sorted(parameters, key=lambda p: (p.kind, p.name))
+        parameters = sorted(parameters, key=lambda p: p.default is None)
         return inspect_sig.Signature(parameters=parameters)
 
     @staticmethod

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -1381,7 +1381,7 @@ class Fit(HasCovarianceMatrix):
                         raise TypeError(
                             'A value was provided for `{}`, however for {} '
                             'fitting the dependent variable cannot have a value '
-                            'assigned to it.'.format(objective, var.name)
+                            'assigned to it.'.format(var.name, objective)
                         )
             return objective
         else:
@@ -1390,8 +1390,8 @@ class Fit(HasCovarianceMatrix):
                 # be considered separately and has its own non standard
                 # objective function.
                 return VectorLeastSquares
-            if len(model) == 1:
-                if len(model.independent_vars) == 0 and model.dependent_vars[0].name not in bound_arguments.arguments:
+            if len(model) == 1 and len(model.independent_vars) == 0:
+                if model.dependent_vars[0].name not in bound_arguments.arguments:
                     # No data provided means a simple minimization of the Model
                     # parameters is requested, not a fit. Therefore set the
                     # variable to None and return MinimizeModel.

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -1371,7 +1371,7 @@ class Fit(HasCovarianceMatrix):
             # Client is king, return the clients objective. For LogLikelihood
             # though, we do check if the data is compatible with likelihood
             # fitting.
-            if (objective is LogLikelihood or objective is MinimizeModel or 
+            if (objective is LogLikelihood or objective is MinimizeModel or
                     isinstance(objective, (MinimizeModel, LogLikelihood))):
                 # Set dependent vars and corresponding sigmas to None.
                 for var in model.dependent_vars + list(model.sigmas.values()):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -491,8 +491,8 @@ class BaseNumericalModel(BaseModel):
             the values of this dict have to be sets.
         """
         connectivity_mapping = kwargs.pop('connectivity_mapping')
-        if connectivity_mapping is None and \
-                independent_vars is not None and params is not None:
+        if (connectivity_mapping is None and
+                independent_vars is not None and params is not None):
             # Make model into a mapping if needed.
             if not isinstance(model, Mapping):
                 try:
@@ -1371,8 +1371,8 @@ class Fit(HasCovarianceMatrix):
             # Client is king, return the clients objective. For LogLikelihood
             # though, we do check if the data is compatible with likelihood
             # fitting.
-            if objective is LogLikelihood or objective is MinimizeModel or \
-                    isinstance(objective, (MinimizeModel, LogLikelihood)):
+            if (objective is LogLikelihood or objective is MinimizeModel or 
+                    isinstance(objective, (MinimizeModel, LogLikelihood))):
                 # Set dependent vars and corresponding sigmas to None.
                 for var in model.dependent_vars + list(model.sigmas.values()):
                     if var.name not in bound_arguments.arguments:
@@ -1390,15 +1390,15 @@ class Fit(HasCovarianceMatrix):
                 # be considered separately and has its own non standard
                 # objective function.
                 return VectorLeastSquares
-            if len(model) == 1 and len(model.independent_vars) == 0:
-                if model.dependent_vars[0].name not in bound_arguments.arguments:
-                    # No data provided means a simple minimization of the Model
-                    # parameters is requested, not a fit. Therefore set the
-                    # variable to None and return MinimizeModel.
-                    for var in model.dependent_vars:
-                        if var.name not in bound_arguments.arguments:
-                            bound_arguments.arguments[var.name] = None
-                    return MinimizeModel
+            if (len(model) == 1 and len(model.independent_vars) == 0 and
+                model.dependent_vars[0].name not in bound_arguments.arguments):
+                # No data provided means a simple minimization of the Model
+                # parameters is requested, not a fit. Therefore set the
+                # variable to None and return MinimizeModel.
+                for var in model.dependent_vars:
+                    if var.name not in bound_arguments.arguments:
+                        bound_arguments.arguments[var.name] = None
+                return MinimizeModel
         return LeastSquares
 
     def _init_minimizer(self, minimizer, **minimizer_options):

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -71,7 +71,7 @@ class BaseMinimizer(object):
                     connectivity_mapping={y: set(self.parameters)}
                 )
             return objective_type(model,
-                                  data={y: None for y in model.dependent_vars})
+                                  data={})
 
     @abc.abstractmethod
     def execute(self, **options):

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -133,7 +133,7 @@ class BaseObjective(object):
         TypeError when this is not the case.
         """
         # Simply checking for existence of these dicts will raise an error if
-        # they cannot be built.
+        # they cannot be built (because these are properties).
         self.dependent_data
         self.independent_data
         self.sigma_data

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -885,7 +885,8 @@ class TestConstrained(unittest.TestCase):
         self.assertEqual({k for k, v in fit.data.items() if v is not None},
                          {x, y, dx, M, I, fit.model.sigmas[y]})
         # These belong to internal variables
-        self.assertEqual({k for k, v in fit.data.items() if v is None}, set())
+        self.assertEqual({k for k, v in fit.data.items() if v is None},
+                         {constraint.sigmas[Y], Y})
 
         constr_result = fit.execute()
         # The constraint should not be met for the unconstrained fit

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -197,7 +197,7 @@ class FiniteDifferenceTests(unittest.TestCase):
         noise = np.random.normal(1, 0.05, size=t_data.shape)
         x_data = ode_model(t=t_data, k=100).x * noise
 
-        ode_fit = sf.Fit(ode_model, t=t_data, x=x_data)
+        ode_fit = sf.Fit(ode_model, t=t_data, x=x_data, v=None)
         ode_result = ode_fit.execute()
 
         phi = 0

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -160,75 +160,6 @@ class Tests(unittest.TestCase):
         # the parameter without data should be unchanged.
         self.assertAlmostEqual(fit_none_result.value(c), 1.0)
 
-    @unittest.skip('Vector models fail in NumericalLeastSquares with bounds. '
-                   'However, this object is no longer used by Fit by default.')
-    def test_vector_fitting_bounds_guess(self):
-        """
-        Tests fitting to a 3 component vector valued function, with bounds and
-        guesses.
-        """
-        a, b, c = parameters('a, b, c')
-        a.min = 0
-        a.value = 10
-        a.max = 25
-        b.min = 0
-        b.max = 500
-        b.value = 100
-        a_i, b_i, c_i = variables('a_i, b_i, c_i')
-
-        model = {a_i: a, b_i: b, c_i: c}
-
-        xdata = np.array([
-            [10.1, 9., 10.5, 11.2, 9.5, 9.6, 10.],
-            [102.1, 101., 100.4, 100.8, 99.2, 100., 100.8],
-            [71.6, 73.2, 69.5, 70.2, 70.8, 70.6, 70.1],
-        ])
-
-        fit = NumericalLeastSquares(
-            model=model,
-            a_i=xdata[0],
-            b_i=xdata[1],
-            c_i=xdata[2],
-        )
-        fit_result = fit.execute()
-
-        self.assertAlmostEqual(fit_result.value(a), np.mean(xdata[0]), 4)
-        self.assertAlmostEqual(fit_result.value(b), np.mean(xdata[1]), 4)
-        self.assertAlmostEqual(fit_result.value(c), np.mean(xdata[2]), 4)
-
-    @unittest.skip('Vector models fail in NumericalLeastSquares with bounds.'
-                   'However, this object is no longer used by Fit by default.')
-    def test_vector_fitting_bounds(self):
-        """
-        Tests fitting to a 3 component vector valued function, with bounds.
-        """
-        a, b, c = parameters('a, b, c')
-        a.min = 0
-        a.max = 25
-        b.min = 0
-        b.max = 500
-        a_i, b_i, c_i = variables('a_i, b_i, c_i')
-
-        model = {a_i: a, b_i: b, c_i: c}
-
-        xdata = np.array([
-            [10.1, 9., 10.5, 11.2, 9.5, 9.6, 10.],
-            [102.1, 101., 100.4, 100.8, 99.2, 100., 100.8],
-            [71.6, 73.2, 69.5, 70.2, 70.8, 70.6, 70.1],
-        ])
-
-        fit = NumericalLeastSquares(
-            model=model,
-            a_i=xdata[0],
-            b_i=xdata[1],
-            c_i=xdata[2],
-        )
-        fit_result = fit.execute()
-
-        self.assertAlmostEqual(fit_result.value(a), np.mean(xdata[0]), 4)
-        self.assertAlmostEqual(fit_result.value(b), np.mean(xdata[1]), 4)
-        self.assertAlmostEqual(fit_result.value(c), np.mean(xdata[2]), 4)
-
     def test_vector_fitting_guess(self):
         """
         Tests fitting to a 3 component vector valued function, with guesses.
@@ -285,41 +216,6 @@ class Tests(unittest.TestCase):
 
         self.assertIsInstance(fit_result.r_squared, float)
         self.assertEqual(fit_result.r_squared, 1.0)  # by definition since there's no fuzzyness
-
-    # def test_analytical_fitting(self):
-    #     """
-    #     Tests fitting using AnalyticalFit. Makes sure that the resulting
-    #     objects and values are of the right type, and that the fit_result does
-    #     not have unexpected members.
-    #     """
-    #     xdata = np.linspace(1, 10, 10)
-    #     ydata = 3*xdata + 2
-    #
-    #     a = Parameter()
-    #     b = Parameter()
-    #     x = Variable('x')
-    #     new = b*x + a
-    #
-    #     fit = AnalyticalFit(new, xdata, ydata)
-    #     fit_result = fit.execute()
-    #     print(fit_result)
-    #
-    #
-    #     self.assertIsInstance(fit_result, FitResults)
-    #     self.assertAlmostEqual(fit_result.params.a, 3.0)
-    #     self.assertAlmostEqual(fit_result.params.b, 2.0)
-    #
-    #     self.assertIsInstance(fit_result.params.a_stdev, float)
-    #     self.assertIsInstance(fit_result.params.b_stdev, float)
-    #
-    #     self.assertIsInstance(fit_result.r_squared, float)
-    #
-    #     # Test several false ways to access the data.
-    #     self.assertRaises(AttributeError, getattr, *[fit_result.params, 'a_fdska'])
-    #     self.assertRaises(AttributeError, getattr, *[fit_result.params, 'c'])
-    #     self.assertRaises(AttributeError, getattr, *[fit_result.params, 'a_stdev_stdev'])
-    #     self.assertRaises(AttributeError, getattr, *[fit_result.params, 'a_stdev_'])
-    #     self.assertRaises(AttributeError, getattr, *[fit_result.params, 'a__stdev'])
 
     def test_grid_fitting(self):
         """

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -357,7 +357,7 @@ class TestMinimize(unittest.TestCase):
 
         # No scipy style dicts allowed.
         with self.assertRaises(TypeError):
-            fit = SLSQP(MinimizeModel(model, data={}),
+            fit = SLSQP(MinimizeModel(model, data=data_dict),
                         parameters=[a, b, c],
                         constraints=[
                             {'type': 'eq', 'fun': lambda a, b, c: a - c}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -152,25 +152,26 @@ class TestModel(unittest.TestCase):
             numerical_model(x=xdata, a=5.5, b=15.0),
             mixed_model(x=xdata, a=5.5, b=15.0)
         )
+        zdata = mixed_model(x=xdata, a=5.5, b=15.0).z + np.random.normal(0, 1)
 
         # Check if the fits are the same
-        fit = Fit(model, x=xdata, y=ydata)
-        analytical_result = fit.execute()
-        fit = Fit(numerical_model, x=xdata, y=ydata)
+        fit = Fit(mixed_model, x=xdata, y=ydata, z=zdata)
+        mixed_result = fit.execute()
+        fit = Fit(numerical_model, x=xdata, y=ydata, z=zdata)
         numerical_result = fit.execute()
         for param in [a, b]:
             self.assertAlmostEqual(
-                analytical_result.value(param),
+                mixed_result.value(param),
                 numerical_result.value(param)
             )
             self.assertAlmostEqual(
-                analytical_result.stdev(param),
+                mixed_result.stdev(param),
                 numerical_result.stdev(param)
             )
-        self.assertAlmostEqual(analytical_result.r_squared, numerical_result.r_squared)
+        self.assertAlmostEqual(mixed_result.r_squared, numerical_result.r_squared)
 
         # Test if the constrained syntax is supported
-        fit = Fit(numerical_model, x=xdata, y=ydata, constraints=[Eq(a, b)])
+        fit = Fit(numerical_model, x=xdata, y=ydata, z=zdata, constraints=[Eq(a, b)])
         constrained_result = fit.execute()
         self.assertAlmostEqual(constrained_result.value(a), constrained_result.value(b))
 

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -46,10 +46,10 @@ class TestObjectives(unittest.TestCase):
         Test the picklability of the built-in objectives.
         """
         # Create test data
-        xdata = np.linspace(0, 100, 25)  # From 0 to 100 in 100 steps
+        xdata = np.linspace(0, 100, 100)  # From 0 to 100 in 100 steps
         a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
         b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
-        ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
+        ydata = a_vec * xdata + b_vec  # Point scattered around the line 15 * x + 100
 
         # Normal symbolic fit
         a = Parameter('a', value=0, min=0.0, max=1000)

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -11,7 +11,8 @@ from symfit import (
     IndexedBase, symbols, Sum, log
 )
 from symfit.core.objectives import (
-    VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel
+    VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel,
+    BaseIndependentObjective
 )
 from symfit.core.fit_results import FitResults
 from symfit.core.printing import SymfitNumPyPrinter
@@ -57,7 +58,12 @@ class TestObjectives(unittest.TestCase):
         model = Model({y: a * x + b})
 
         for objective in [VectorLeastSquares, LeastSquares, LogLikelihood, MinimizeModel]:
-            obj = objective(model, data={'x': xdata, 'y': ydata})
+            if issubclass(objective, BaseIndependentObjective):
+                data = {x: xdata}
+            else:
+                data = {x: xdata, y: ydata,
+                        model.sigmas[y]: np.ones_like(ydata)}
+            obj = objective(model, data=data)
             new_obj = pickle.loads(pickle.dumps(obj))
             self.assertTrue(FitResults._array_safe_dict_eq(obj.__dict__,
                                                            new_obj.__dict__))
@@ -180,7 +186,7 @@ class TestObjectives(unittest.TestCase):
                                        hess_numerical)
         self.assertIsInstance(hess_numerical, np.ndarray)
 
-        fit = Fit(logL_exact, x=xdata, y=None, objective=MinimizeModel)
+        fit = Fit(logL_exact, x=xdata, objective=MinimizeModel)
         fit_exact_result = fit.execute()
         fit = Fit(logL_model, x=xdata, objective=LogLikelihood)
         fit_num_result = fit.execute()
@@ -189,7 +195,41 @@ class TestObjectives(unittest.TestCase):
         self.assertAlmostEqual(fit_exact_result.stdev(a), fit_num_result.stdev(a))
         self.assertAlmostEqual(fit_exact_result.stdev(b), fit_num_result.stdev(b))
 
+    def test_data_sanity(self):
+        """
+        Tests very basicly the data sanity for different objective types.
+        :return:
+        """
+        # Create test data
+        xdata = np.linspace(0, 100, 25)  # From 0 to 100 in 100 steps
+        a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
+        b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
+        ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
 
+        # Normal symbolic fit
+        a = Parameter('a', value=0, min=0.0, max=1000)
+        b = Parameter('b', value=0, min=0.0, max=1000)
+        x, y, z = variables('x, y, z')
+        model = Model({y: a * x + b})
+
+        for objective in [VectorLeastSquares, LeastSquares, LogLikelihood,
+                          MinimizeModel]:
+            if issubclass(objective, BaseIndependentObjective):
+                incomplete_data = {}
+                data = {x: xdata}
+                overcomplete_data = {x: xdata, z: ydata}
+            else:
+                incomplete_data = {x: xdata, y: ydata}
+                data = {x: xdata, y: ydata,
+                        model.sigmas[y]: np.ones_like(ydata)}
+                overcomplete_data = {x: xdata, y: ydata, z: ydata,
+                        model.sigmas[y]: np.ones_like(ydata)}
+            with self.assertRaises(KeyError):
+                obj = objective(model, data=incomplete_data)
+            obj = objective(model, data=data)
+            # Overcomplete data has to be allowed, since constraints share their
+            # data with models.
+            obj = objective(model, data=overcomplete_data)
 
 if __name__ == '__main__':
     try:

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -202,7 +202,7 @@ class TestODE(unittest.TestCase):
     def test_odemodel_sanity(self):
         """
         If a user provides an ODE like model directly to fit without
-        explicitely turning it into one, give a warning.
+        explicitly turning it into one, give a warning.
         """
         tdata = np.array([0, 10, 26, 44, 70, 120])
         adata = 10e-4 * np.array([54, 44, 34, 27, 20, 14])
@@ -212,13 +212,7 @@ class TestODE(unittest.TestCase):
         model_dict = {
             D(a, t): - k * a * t,
         }
-        with pytest.warns(RuntimeWarning):
-            fit = Fit(model_dict, t=tdata, a=adata)
-
-        model_dict = {
-            a: - k * D(a, t) * t,
-        }
-        with pytest.warns(RuntimeWarning):
+        with self.assertRaises(RuntimeWarning):
             fit = Fit(model_dict, t=tdata, a=adata)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed #214. Variables are no longer set to None by default, all variables now need to be provided explicitly with data or None, unless `Fit` can infer from the data, model and objective provided that some should be ignored. This way debugging will be greatly improved, since currently it is still allowed to forget to provide data which causes a lot of pain when debugging.

Only important API change:  `None` has to be provided explicitly to `Fit` when no data is present for a variable.