### PR TITLE
Updated setup.cfg to reflect travis versions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,9 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 keywords = fit fitting symbolic
 
 [bdist_wheel]


### PR DESCRIPTION
Removed py3.4 due to end-of-life, and added 3.6 and 3.7, such that setup.cfg also reflects our tested Travis-CI versions.