### PR TITLE
added try/except to version finding

### DIFF
--- a/symfit/__init__.py
+++ b/symfit/__init__.py
@@ -1,4 +1,7 @@
 from symfit.api import *
 import pkg_resources
 
-__version__  = pkg_resources.get_distribution('symfit').version
+try:
+    __version__ = pkg_resources.get_distribution('symfit').version
+except pkg_resources.DistributionNotFound:
+    __version__ = ''


### PR DESCRIPTION
For those who use `conda develop` to use one of symfit's branches or the current master. Currently, when doing so, the version cannot be found and an error is raised.