### PR TITLE
Fixed #271 by lazily creating Hessian and Jacobian models

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -516,14 +516,14 @@ class Fit(HasCovarianceMatrix):
             # that, otherwise we let the minimizer estimate it itself.
             # Hence the check of jacobian_model, as this is the
             # py function version of the analytical jacobian.
-            if hasattr(self.model, 'jacobian_model') and hasattr(self.objective, 'eval_jacobian'):
+            if hasattr(self.model, 'eval_jacobian') and hasattr(self.objective, 'eval_jacobian'):
                 minimizer_options['jacobian'] = self.objective.eval_jacobian
         if issubclass(minimizer, HessianMinimizer):
             # If an analytical version of the Hessian exists we should use
             # that, otherwise we let the minimizer estimate it itself.
             # Hence the check of hessian_model, as this is the
             # py function version of the analytical hessian.
-            if hasattr(self.model, 'hessian_model') and hasattr(self.objective, 'eval_hessian'):
+            if hasattr(self.model, 'eval_hessian') and hasattr(self.objective, 'eval_hessian'):
                 minimizer_options['hessian'] = self.objective.eval_hessian
 
         if issubclass(minimizer, ConstrainedMinimizer):

--- a/symfit/core/fit_results.py
+++ b/symfit/core/fit_results.py
@@ -112,7 +112,7 @@ class FitResults(object):
         """
         try:
             return np.sqrt(self.variance(param))
-        except AttributeError:
+        except (AttributeError, TypeError):
             # This happens when variance returns None.
             return None
 

--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -593,13 +593,14 @@ class BaseCallableModel(BaseModel):
              '`numerical_components`.').format(self.__class__)
         )
 
-    def _get_params(self):
+    @property
+    def params(self):
         return self._params
 
-    def _set_params(self, value):
+    @params.setter
+    def params(self, value):
         self._params = value
         self.__signature__ = self._make_signature()
-    params = property(_get_params, _set_params)  # Properties cannot use `super`
 
     def _make_signature(self):
         # Handle args and kwargs according to the allowed names.
@@ -793,7 +794,7 @@ class GradientModel(CallableModel, BaseGradientModel):
     @cached_property
     def jacobian_model(self):
         jac_model = jacobian_from_model(self)
-        jac_model.__signature__ = self.__signature__
+        jac_model.params = self.params
         return jac_model
 
     @cached_property
@@ -845,7 +846,7 @@ class HessianModel(GradientModel):
     @cached_property
     def hessian_model(self):
         hess_model = hessian_from_model(self)
-        hess_model.__signature__ = self.__signature__
+        hess_model.params = self.params
         return hess_model
 
     @property

--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -789,14 +789,12 @@ class GradientModel(CallableModel, BaseGradientModel):
     """
     def __init__(self, *args, **kwargs):
         super(GradientModel, self).__init__(*args, **kwargs)
-        self.jacobian_model = jacobian_from_model(self)
 
-    def _set_params(self, value):
-        super(GradientModel, self)._set_params(value)
-        if hasattr(self, 'jacobian_model'):
-            self.jacobian_model.params = value
-    # Properties cannot use `super` unless when used in this way
-    params = property(CallableModel._get_params, _set_params)
+    @cached_property
+    def jacobian_model(self):
+        jac_model = jacobian_from_model(self)
+        jac_model.__signature__ = self.__signature__
+        return jac_model
 
     @cached_property
     def jacobian(self):
@@ -843,14 +841,12 @@ class HessianModel(GradientModel):
     """
     def __init__(self, *args, **kwargs):
         super(HessianModel, self).__init__(*args, **kwargs)
-        self.hessian_model = hessian_from_model(self)
 
-    def _set_params(self, value):
-        super(HessianModel, self)._set_params(value)
-        if hasattr(self, 'hessian_model'):
-            self.hessian_model.params = value
-    # Properties cannot use `super` unless when used in this way
-    params = property(GradientModel._get_params, _set_params)
+    @cached_property
+    def hessian_model(self):
+        hess_model = hessian_from_model(self)
+        hess_model.__signature__ = self.__signature__
+        return hess_model
 
     @property
     def hessian(self):


### PR DESCRIPTION
Hessian and Jacobian models are only created when they are needed. For most use cases, this means the Hessian will no longer be calculated. This is a huge speedup gain, comparing to the code provided in #271, we get the following timings:

```
identical components, time (s)
1 0.005013465881347656
2 0.0010039806365966797
3 0.0010023117065429688
4 0.0010018348693847656
5 0.0010030269622802734
6 0.0010023117065429688
7 0.002006053924560547
8 0.0010023117065429688
9 0.002004861831665039
10 0.0020058155059814453
```
whereas in 0.5.1 it was
```
identical components, time (s)
1 0.0671529769897461
2 0.20554876327514648
3 0.8522927761077881
4 2.4235997200012207
5 5.880227088928223
6 13.202399969100952
7 25.026122331619263
8 42.70384192466736
...
```

The penalty will still occur if you actually use a Hessian minimizer, so don't.