### PR TITLE
Replace variabletuple by an object ModelOutput.

### DIFF
--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -19,7 +19,17 @@ else:
     import funcsigs as inspect_sig
 
 
-class ModelOutput(Sequence):
+class ModelOutput(tuple):
+    def __new__(self, variables, output):
+        """
+        ``variables`` and ``output`` need to be in the same order!
+
+        :param variables: The variables corresponding to ``output``.
+        :param output: The output of a call which should be mapped to
+            ``variables``.
+        """
+        return tuple.__new__(ModelOutput, output)
+
     def __init__(self, variables, output):
         """
         ``variables`` and ``output`` need to be in the same order!

--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -47,13 +47,13 @@ class ModelOutput(tuple):
         try:
             var = self.variable_names[name]
         except KeyError as err:
-            raise AttributeError(err.msg)
+            raise AttributeError(err)
         return self.output_dict[var]
 
     def __getitem__(self, key):
         return self.output[key]
 
-    def __str__(self):
+    def __repr__(self):
         return self.__class__.__name__ + '(variables={}, output={})'.format(self.variables, self.output)
 
     def _asdict(self):

--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, Mapping, OrderedDict, Sequence
+from collections import Mapping, OrderedDict
 import warnings
 import sys
 
@@ -20,6 +20,26 @@ else:
 
 
 class ModelOutput(tuple):
+    """
+    Object to hold the output of a model call. It mimics a
+    :func:`collections.namedtuple`, but is initiated with
+    :class:`~symfit.core.argument.Variable` objects instead of strings.
+
+    Its information can be accessed using indexing or as attributes::
+
+        >>> x, y = variables('x, y')
+        >>> a, b = parameters('a, b')
+        >>> model = Model({y: a * x + b})
+
+        >>> ans = model(x=2, a=1, b=3)
+        >>> print(ans)
+        ModelOutput(variables=[y], output=[5])
+        >>> ans[0]
+        5
+        >>> ans.y
+        5
+
+    """
     def __new__(self, variables, output):
         """
         ``variables`` and ``output`` need to be in the same order!

--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -77,7 +77,10 @@ class ModelOutput(tuple):
         return self.__class__.__name__ + '(variables={}, output={})'.format(self.variables, self.output)
 
     def _asdict(self):
-        return self.output_dict
+        """
+        :return: Returns a new OrderedDict representing this object.
+        """
+        return self.output_dict.copy()
 
     def __len__(self):
         return len(self.output_dict)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,7 +15,7 @@ from symfit import (
     Function, diff
 )
 from symfit.core.models import (
-    jacobian_from_model, hessian_from_model, ModelError
+    jacobian_from_model, hessian_from_model, ModelError, ModelOutput
 )
 
 class TestModel(unittest.TestCase):
@@ -106,9 +106,11 @@ class TestModel(unittest.TestCase):
 
         xdata = np.linspace(0, 10)
         ydata = model(x=xdata, a=5.5, b=15.0).y + np.random.normal(0, 1)
+        ans1= model(x=xdata, a=5.5, b=15.0)
+        ans2 = numerical_model(x=xdata, a=5.5, b=15.0)
         np.testing.assert_almost_equal(
-            model(x=xdata, a=5.5, b=15.0),
-            numerical_model(x=xdata, a=5.5, b=15.0),
+            tuple(ans1),
+            tuple(ans2)
         )
 
         faulty_model = CallableNumericalModel({y: lambda x, a, b: a * x + b},
@@ -446,6 +448,17 @@ class TestModel(unittest.TestCase):
 
         self.assertEqual(model.__signature__, model.jacobian_model.__signature__)
         self.assertEqual(model.__signature__, model.hessian_model.__signature__)
+
+    def test_ModelOutput(self):
+        """
+        Test the ModelOutput object. To prevent #267 from recurring,
+        we attempt to make a model with more than 255 variables.
+        """
+        params = parameters(','.join('a{}'.format(i) for i in range(300)))
+        data = np.ones(300)
+        output = ModelOutput(params, data)
+        self.assertEqual(len(output), 300)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -106,11 +106,9 @@ class TestModel(unittest.TestCase):
 
         xdata = np.linspace(0, 10)
         ydata = model(x=xdata, a=5.5, b=15.0).y + np.random.normal(0, 1)
-        ans1= model(x=xdata, a=5.5, b=15.0)
-        ans2 = numerical_model(x=xdata, a=5.5, b=15.0)
         np.testing.assert_almost_equal(
-            tuple(ans1),
-            tuple(ans2)
+            model(x=xdata, a=5.5, b=15.0),
+            numerical_model(x=xdata, a=5.5, b=15.0),
         )
 
         faulty_model = CallableNumericalModel({y: lambda x, a, b: a * x + b},

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -456,6 +456,8 @@ class TestModel(unittest.TestCase):
         data = np.ones(300)
         output = ModelOutput(params, data)
         self.assertEqual(len(output), 300)
+        self.assertIsInstance(output._asdict(), OrderedDict)
+        self.assertIsNot(output._asdict(), output.output_dict)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A PR to solve #267 by removing the `variabletuple` and replacing it with an object `ModelOutput`, which has the same API.

So far this seems to work almost everywhere, except that numpy's `assert_almost_equal` does not like these objects, despite the fact that they are iterable and therefore I don't see why this is different from the old `tuple` subclass.