### PR TITLE
Added metaclass to create dummy Paramter/Variables

### DIFF
--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -2,10 +2,24 @@ from collections import defaultdict
 import numbers
 import warnings
 
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Symbol, Dummy
+from sympy.core.assumptions import ManagedProperties
+import builtins
 
 
-class Argument(Symbol):
+class DummyMeta(ManagedProperties):
+
+    def __new__(cls, name, bases, namespace, **kwargs):
+        try:
+            if name == 'Argument' and builtins.symfit_dummy:
+                bases = (Dummy, )
+        except AttributeError:
+            pass
+
+        cls = super().__new__(cls, name, bases, namespace)
+        return cls
+
+class Argument(Symbol, metaclass=DummyMeta):
     """
     Base class for :mod:`symfit` symbols. This helps make :mod:`symfit` symbols
     distinguishable from :mod:`sympy` symbols.


### PR DESCRIPTION
This is a bit of a hack, but it allows users to force creation of dummy Parameter / Variables instead of symbol ones (see #290).

Usage:
```python
import builtins
builtins.symfit_dummy = True

from symfit import Parameter

a = Parameter('x', value=2)
b = Parameter('x', value=3)

print(a.value, b.value)


>>> (2, 3)
```

Where in normal ``symfit`` behaviour the result would be ``(3, 3)``.

Why would you want to use this? Well, if your application of ``symfit`` is one script, one model kind of fitting then there is probably very little use. But if you make a bigger application where many models are created and active at the same time (thread safe?) then dummy behaviour is desired.

Also, lets say you happen to be making your parmeters like this:

```python
A = Parameter()
sig = Parameter('par_0')
```
Without dummies, these two parameters are the same, and fitting fails without an error. With dummies, it still doesnt work, but at least you get an error :)

Yes, I agree the implementation is a bit sketchy and could be considered dark magic. Suggestions are welcome. Maybe some split of the inheritance into ``Parameter`` and ``DummyParameter``, but because of all the implementations of ``__new__`` it seems that ``Dummy`` somehow needs to be introduced just after ``Argument`` in the mro. 
The hack via ``builtins`` is needed because the information on wheter to dummy or not needs to be passed before any symfit imports as that is when the classes are created.
``builtins`` is py3 only (did we drop py2 already?)