### PR TITLE
Support for tensorflow BFGS and DifferentialEvolution minimizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
 install:
   - pip install --upgrade -r requirements.txt
   - pip install .[all]
+  - pip install --upgrade tensorflow
+  - pip install --upgrade tensorflow-probability
 
 before_script:
   - pip install --upgrade pytest coveralls

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -70,6 +70,7 @@ class Argument(Symbol):
     _lambdacode = _sympystr
     _numpycode = _sympystr
     _pythoncode = _sympystr
+    _tensorflowcode = _sympystr
 
 class Parameter(Argument):
     """

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -211,7 +211,7 @@ class TakesData(object):
             if data is not None:
                 dependent_shapes.append(data.shape)
 
-        return list(set(independent_shapes)), list(set(dependent_shapes))
+        return list(np.unique(independent_shapes)), list(np.unique(dependent_shapes))
 
     @property
     def initial_guesses(self):
@@ -577,9 +577,10 @@ class Fit(HasCovarianceMatrix):
         :return: FitResults instance
         """
         minimizer_ans = self.minimizer.execute(**minimize_options)
-        minimizer_ans.covariance_matrix = self.covariance_matrix(
-            dict(zip(self.model.params, minimizer_ans._popt))
-        )
+        if minimizer_ans.covariance_matrix is None:
+            minimizer_ans.covariance_matrix = self.covariance_matrix(
+                dict(zip(self.model.params, minimizer_ans._popt))
+            )
         # Overwrite the DummyModel with the current model
         minimizer_ans.model = self.model
         minimizer_ans.minimizer = self.minimizer

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -104,6 +104,7 @@ class BaseMinimizer(object):
         self.__dict__.update(state)
         self.__init__(**self._pickle_kwargs)
 
+
 class BoundedMinimizer(BaseMinimizer):
     """
     ABC for Minimizers that support bounds.
@@ -111,6 +112,7 @@ class BoundedMinimizer(BaseMinimizer):
     @property
     def bounds(self):
         return [(p.min, p.max) for p in self.params]
+
 
 class ConstrainedMinimizer(BaseMinimizer):
     """

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -89,41 +89,7 @@ class BaseObjective(object):
         parameters.update(self._invariant_kwargs)
         result = self.model(**key2str(parameters))._asdict()
         # Return only the components corresponding to the dependent data.
-        return self._shape_of_dependent_data(
-            [comp for var, comp in result.items()
-             if var in self.model.dependent_vars]
-        )
-
-    def _shape_of_dependent_data(self, model_output, param_level=0):
-        """
-        In rare cases, the dependent data and the output of the model do not
-        have the same shape. Think for example about :math:`y_i = a`. This
-        function makes sure both sides of the equation have the same shape.
-
-        :param model_output: Output of a call to model
-        :param param_level: indicates how many parameter dimensions should be
-            added to the shape. 0 for __call__, 1 for jac, 2 for hess.
-        :return: ``model_output`` reshaped to ``dependent_data``'s shape, if
-            possible.
-        """
-        shaped_result = []
-        n_params = len(self.model.params)
-        for dep_var, component in zip(self.model.dependent_vars, model_output):
-            dep_data = self.dependent_data.get(dep_var, None)
-            if dep_data is not None:
-                if dep_data.shape == component.shape:
-                    shaped_result.append(component)
-                else:
-                    # Add extra dimensions to the component if needed.
-                    dim_diff = len(dep_data.shape) - len(component.shape[param_level:])
-                    for _ in range(dim_diff):
-                        component = np.expand_dims(component, -1)
-                    # Let numpy deal with all the broadcasting
-                    shape = param_level * [n_params] + list(dep_data.shape)
-                    shaped_result.append(np.broadcast_to(component, shape))
-            else:
-                shaped_result.append(component)
-        return shaped_result
+        return [comp for var, comp in result.items() if var in self.model.dependent_vars]
 
     @cached_property
     def _invariant_kwargs(self):
@@ -196,11 +162,7 @@ class GradientObjective(BaseObjective):
         parameters.update(self._invariant_kwargs)
         result = self.model.eval_jacobian(**key2str(parameters))._asdict()
         # Return only the components corresponding to the dependent data.
-        return self._shape_of_dependent_data(
-            [comp for var, comp in result.items()
-             if var in self.model.dependent_vars],
-            param_level=1
-        )
+        return [comp for var, comp in result.items() if var in self.model.dependent_vars]
 
 
 @add_metaclass(abc.ABCMeta)
@@ -221,12 +183,7 @@ class HessianObjective(GradientObjective):
         parameters.update(dict(zip(self.model.free_params, ordered_parameters)))
         parameters.update(self._invariant_kwargs)
         result = self.model.eval_hessian(**key2str(parameters))._asdict()
-        # Return only the components corresponding to the dependent data.
-        return self._shape_of_dependent_data(
-            [comp for var, comp in result.items()
-             if var in self.model.dependent_vars],
-            param_level=2
-        )
+        return [comp for var, comp in result.items() if var in self.model.dependent_vars]
 
 
 class VectorLeastSquares(GradientObjective):

--- a/symfit/core/tf_minimizers.py
+++ b/symfit/core/tf_minimizers.py
@@ -1,0 +1,108 @@
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from symfit.core.minimizers import GradientMinimizer, GlobalMinimizer
+from symfit.core.support import keywordonly
+from symfit.core.fit_results import FitResults
+
+class TensorflowOptimizer(object):
+    """
+    Mix-in class that handles the execute calls to :func:`tensorflow.optimizer.
+    """
+    @classmethod
+    def method_name(cls):
+        """
+        Returns the name of the minimize method this object represents. This is
+        needed because the name of the object is not always exactly what needs
+        to be passed on to scipy as a string.
+        :return:
+        """
+        return cls.__name__
+
+class TFBFGS(TensorflowOptimizer, GradientMinimizer):
+    @keywordonly(jacobian=None)
+    def execute(self, **minimize_options):
+        jacobian = minimize_options.pop('jacobian')
+        if jacobian is None:
+            jacobian = self.wrapped_jacobian
+        ans = tfp.optimizer.bfgs_minimize(
+            value_and_gradients_function=lambda *args: [
+                tf.numpy_function(self.objective.__call__, args, args[0].dtype),
+                tf.numpy_function(jacobian, args, args[0].dtype)
+            ],
+            initial_position=self.initial_guesses,
+            **minimize_options
+        )
+
+        ans = FitResults(
+            model=self.objective.model,
+            popt=ans.position,
+            covariance_matrix=ans.inverse_hessian_estimate,
+            minimizer=self,
+            objective=self.objective,
+            message=f'Converged: {ans.converged}',
+            fun=ans.objective_value,
+            nit=ans.num_iterations)
+        return ans
+
+class TFDifferentialEvolution(TensorflowOptimizer, GlobalMinimizer):
+    """
+    Wraps :func:`~tensorflow_probability.optimizer.differential_evolution_minimize` for a parallel version of the
+    Differential Evolution algorithm with optional GPU support. This requires Tensorflow and Tensorflow-probability to
+    be installed, and we refer to their documentation for more information.
+
+    Example usage::
+
+        a = Parameter('a', value=1.0, min=0.0, max=100.0)
+        b = Parameter('b', value=1.0, min=0.0, max=100.0)
+        x = Variable('x')
+        y = Variable('y')
+        model = Model({y: a * x + b})
+
+        # Generate data using Tensorflow
+        xdata = tf.linspace(0, 100, 25)  # From 0 to 100 in 100 steps
+        a_vec = tf.random.normal(15.0, scale=2.0, size=xdata.shape)
+        b_vec = tf.random.normal(100, scale=2.0, size=xdata.shape)
+        ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
+
+        # Add an extra dimension to allow broadcasting
+        xdata = xdata[..., None]
+        ydata = ydata[..., None]
+        fit = Fit(model, xdata, ydata, minimizer=TFDifferentialEvolution)
+        tf_fit_result = fit.execute()
+
+    .. warning::
+        For TFDifferentialEvolution the datasets need to be tensors of tf.float32, and an extra dimension needs to be
+        added to the datasets because tf will call the model with an array of size `population_size` for each parameter.
+    """
+
+    def execute(self, *, population_size=40, **minimize_options):
+        """
+        Execute a tensorflow differential evolution. Check the docs of
+            :func:`~tensorflow_probability.optimizer.differential_evolution_minimize` for more information on the
+            various options.
+        :param population_size: The size of the population to evolve. This parameter is ignored if initial_population
+            is specified.
+        :param minimize_options: Options to pass to :func:`~tensorflow_probability.optimizer.differential_evolution_minimize`.
+        :return:
+        """
+        initial_position = [tf.constant(val) for val in self.initial_guesses] if 'initial_population' not in minimize_options else None
+        ans = tfp.optimizer.differential_evolution_minimize(
+            lambda *args: (
+                tf.numpy_function(lambda *args: self.objective.__call__(args, tf_differential_evolution=True), args, args[0].dtype)
+            ),
+            initial_position=initial_position,
+            population_size=population_size,
+            **minimize_options
+        )
+
+        ans = FitResults(
+            model=self.objective.model,
+            popt=ans.position,
+            covariance_matrix=None,
+            minimizer=self,
+            objective=self.objective,
+            message=f'Converged: {ans.converged}',
+            fun=ans.objective_value,
+            nit=ans.num_iterations)
+        return ans

--- a/tests/test_tf_minimizers.py
+++ b/tests/test_tf_minimizers.py
@@ -1,0 +1,73 @@
+from __future__ import division, print_function
+import pytest
+import warnings
+
+import numpy as np
+import pickle
+import multiprocessing as mp
+import tensorflow as tf
+
+from symfit import (
+    Variable, Parameter, Fit
+)
+from symfit.core.minimizers import *
+from symfit.core.tf_minimizers import TFBFGS, TFDifferentialEvolution
+
+def test_TFBFGS():
+    """
+    Compare the results of Tensorflow BFGS vs scipy BFGS
+    """
+    # Create test data
+    xdata = np.linspace(0, 100, 25)  # From 0 to 100 in 100 steps
+    a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
+    b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
+    ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
+
+    # Normal symbolic fit
+    a = Parameter('a', value=0.0)
+    b = Parameter('b', value=0.0)
+    x = Variable('x')
+    y = Variable('y')
+    model = {y: a * x + b}
+
+    fit = Fit(model, xdata, ydata, minimizer=BFGS)
+    fit_result = fit.execute()
+
+    xdata = tf.constant(xdata, dtype=tf.float32)
+    ydata = tf.constant(ydata, dtype=tf.float32)
+    fit = Fit(model, xdata, ydata, minimizer=TFBFGS)
+    tf_fit_result = fit.execute()
+
+    assert pytest.approx(fit_result.value(a), tf_fit_result.value(a))
+    assert pytest.approx(fit_result.value(b), tf_fit_result.value(b))
+
+def test_TFDifferentialEvolution():
+    """
+    Compare the results of Tensorflow BFGS vs scipy BFGS
+    """
+    # Create test data
+    xdata = np.linspace(0, 100, 25)  # From 0 to 100 in 100 steps
+    a_vec = np.random.normal(15.0, scale=2.0, size=xdata.shape)
+    b_vec = np.random.normal(100, scale=2.0, size=xdata.shape)
+    ydata = a_vec * xdata + b_vec  # Point scattered around the line 5 * x + 105
+
+    # Normal symbolic fit
+    a = Parameter('a', value=1.0, min=0.0, max=100.0)
+    b = Parameter('b', value=1.0, min=0.0, max=100.0)
+    x = Variable('x')
+    y = Variable('y')
+    model = {y: a * x + b}
+
+    fit = Fit(model, xdata, ydata, minimizer=DifferentialEvolution)
+    fit_result = fit.execute()
+
+    # For TFDifferentialEvolution we need to cast from numpy array to a tensor of
+    # tf.float32, and an extra dimension needs to be added to the datasets because tf
+    # Will call it with an array for each parameter, of size `population_size`
+    xdata = tf.constant(xdata, dtype=tf.float32)[..., None]
+    ydata = tf.constant(ydata, dtype=tf.float32)[..., None]
+    fit = Fit(model, xdata, ydata, minimizer=TFDifferentialEvolution)
+    tf_fit_result = fit.execute()
+
+    assert pytest.approx(fit_result.value(a), tf_fit_result.value(a))
+    assert pytest.approx(fit_result.value(b), tf_fit_result.value(b))


### PR DESCRIPTION
This PR adds an initial implementation of minimization with Tensorflow and is the result of a coding session with @tBuLi 

This allows for GPU fitting support if ``tensorflow-gpu`` is installed and can provide up to (at least) 10-fold performance increase.

Current improvement for BFGS is 10-fold speed increase for big datasets, where a pure tensorflow implementation gives a 30-fold speed increase. This difference is likely due to the implementation of the objective functions and the overhead incurred here, and likely this can be further improved by  factory functions which make the objective function.

This may solve #206 depending on the minimizers used. Future updates may include a [TensorFlow ODE](https://www.tensorflow.org/probability/api_docs/python/tfp/math/ode/Solver) solver and other minimizers.