### PR TITLE
documentation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 .idea
 .cache
 .pytest_cache
-docs_build
 build
 docs/_build
-docs_build
+docs/_doctrees
 dist

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+DOCTREESDIR   = _doctrees
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -15,7 +16,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(DOCTREESDIR) $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,9 @@ htmlhelp_basename = 'symfitdoc'
 # The path to the MathJax JavaScript file to include in the HTML files.
 #mathjax_path = '/usr/share/javascript/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
+# The path to the RequireJS JavaScript file to include in the HTML files.
+#nbsphinx_requirejs_path = '/usr/share/javascript/requirejs/require.min.js'
+
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+#html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,7 +155,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,6 +186,9 @@ html_theme = 'default'
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
+# If true, the reST sources are included in the HTML build. The default is True.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 #html_show_sourcelink = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,6 +212,9 @@ html_copy_source = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'symfitdoc'
 
+# The path to the MathJax JavaScript file to include in the HTML files.
+#mathjax_path = '/usr/share/javascript/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,8 @@ extensions = [
     'nbsphinx',
 ]
 
+# Contains the locations and names of other projects that should be
+# linked to in this documentation.
 intersphinx_mapping = {
     'sympy': ('https://docs.sympy.org/latest', None),
     'python': ('https://docs.python.org/3', None),
@@ -45,6 +47,7 @@ intersphinx_mapping = {
     'matplotlib': ('https://matplotlib.org', None)
 }
 
+# List of targets that should be ignored when generating warnings.
 nitpick_ignore = [
     ('py:mod', 'symfit'),
     ('py:mod', 'symfit.contrib.interactive_guess'),


### PR DESCRIPTION
First of all thanks for this awesome project, it really helped me a lot.

I'm currently working on getting symfit in the official Debian archives. One thing that gave some headache was the documentation though. In Debian, all Python packages / libraries should contain an optional offline documentation.

To begin with, currently when generating the html output, all pictures in `docs/_static` are also copied to `docs/_build/_static`, because `html_static_path` is falsely set to that. It isn't intended for for pictures that are mentioned in the rst files, rather stuff like css files where this doesn't apply. Pictures that are mentioned in the rst files will automatically be copied to `docs/_build/_images`, and this is where the html files actually reference to.

The second thing I noticed was that every rst file is copied to `docs/_build/_sources`. The html pages link to these files as "view source file", however I found that more distracting because a) it isn't the Python code as one might expect, and b) the image paths are wrong. So I disabled that.

I actually noticed the third thing just by chance. The `default` html theme isn't actually the default. The default theme is `alabaster`, which looks way better IMHO, and probably also works better on tablets and stuff. Commenting the setting will use sphinx' default theme (but not the `default` theme, which in fact is the `classic` theme).

Something that isn't strictly necessary but I think a good idea is documenting `mathjax_path`. It took me quite a while to find this variable, so I think it's helpful to mention the variable. What it does is allowing to define a path to `MathJax.js`, instead of using a link to load the script. This is required for a proper offline documentation.

Also something that I would recommend: setting the `.doctrees` dir outside of `_build`. This has two advantages:
1) it keeps `_build` clean, i. e. when building html there are basically only required files in `_build`, meaning the documentation can be deployed by simply copying the entire folder
2) `.doctrees` can be cached, so deleting `_build` won't delete that cache

There also some other stuff I will look into (for me the tests are failing and there are some warnings in the documentation, giving away the full build path).