### PR TITLE
Fix #325: decode status_message of LBFGSB if necessary

### DIFF
--- a/symfit/core/fit_results.py
+++ b/symfit/core/fit_results.py
@@ -39,7 +39,8 @@ class FitResults(object):
         self.model = model
         self.minimizer = minimizer
         self.objective = objective
-        self.status_message = message
+        # LBFGSB returns with python<=3.6 a bit-string as message
+        self.status_message = message.decode() if isinstance(message, bytes) else message
 
         self._popt = popt
         self.params = OrderedDict(


### PR DESCRIPTION
With this PR, `status_messages` will be decoded if the from minimizer  returned message is a bit-string. This is the case when using LBFGSB as minimizer with python<=3.6 (already fixed for python>=3.7 by https://github.com/scipy/scipy/commit/b939e202c60052ea9b7051a1529e0922d70c994a).

fixes #325 