### PR TITLE
Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ jobs:
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
+    - python: "3.9"
 
     - stage: docs
       python: "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifier =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
 
 keywords = fit fitting symbolic
 


### PR DESCRIPTION
Added python 3.9 support to setup config and Travis

Perhaps we should consider dropping python 3.5 and python 3.6 support in a new major release of symfit
(See for example NEP29 version support)