### PR TITLE
Test failures

### DIFF
--- a/symfit/contrib/interactive_guess/interactive_guess.py
+++ b/symfit/contrib/interactive_guess/interactive_guess.py
@@ -4,9 +4,6 @@
 
 # -*- coding: utf-8 -*-
 
-import matplotlib as mpl
-mpl.use('Agg')
-
 from ... import ODEModel, Derivative, latex
 from ...core.fit import TakesData
 from ...core.support import keywordonly, key2str, deprecated

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -62,8 +62,12 @@ class Argument(Symbol):
             self.name = name
         super(Argument, self).__init__()
 
+    def __setstate__(self, state):
+        for key, value in state.items():
+            setattr(self, key, value)
+
     def __getstate__(self):
-        state = super(Argument, self).__getstate__()
+        state = super(Argument, self).__getstate__() or {}
         state.update({slot: getattr(self, slot) for slot in self.__slots__
                       if hasattr(self, slot)})
         return state

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -144,7 +144,7 @@ def test_param_error_analytical():
     """
     N = 10000
     sigma = 25.0
-    xn = np.arange(N, dtype=np.float)
+    xn = np.arange(N, dtype=float)
     np.random.seed(110)
     yn = np.random.normal(size=xn.shape, scale=sigma)
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -773,7 +773,7 @@ def test_error_analytical():
     """
     N = 10000
     sigma = 10.0 * np.ones(N)
-    xn = np.arange(N, dtype=np.float)
+    xn = np.arange(N, dtype=float)
     # yn = np.zeros_like(xn)
     np.random.seed(10)
     yn = np.random.normal(size=len(xn), scale=sigma)


### PR DESCRIPTION
A number of tests are failing. This PR fixes them.
Most failures come from pickle complaining about the slots of the `Argument` class. `sympy.Symbol` used to provide the necessary `__setstate__` method, but not anymore. In addition, its `__getstate__` method started returning `None` rather than an empty dict.

Besides that there's a test that fails due to numerical reasons. This is addressed by slightly changing the values used. It seems much more robust now though, removing the random seed didn't affect the result.