### PR TITLE
Switch out odeint for the more modern solve_ivp

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = symfit
 summary = Symbolic Fitting; fitting as it should be.
-description-file = README.rst
+description_file = README.rst
 author = Martin Roelfs
 author_email = martin.roelfs@kuleuven.be
-home-page = https://github.com/tBuLi/symfit
+home_page = https://github.com/tBuLi/symfit
 license = MIT
 classifier =
     Development Status :: 4 - Beta

--- a/symfit/contrib/interactive_guess/interactive_guess.py
+++ b/symfit/contrib/interactive_guess/interactive_guess.py
@@ -4,9 +4,6 @@
 
 # -*- coding: utf-8 -*-
 
-import matplotlib as mpl
-mpl.use('Agg')
-
 from ... import ODEModel, Derivative, latex
 from ...core.fit import TakesData
 from ...core.support import keywordonly, key2str, deprecated

--- a/symfit/core/argument.py
+++ b/symfit/core/argument.py
@@ -62,8 +62,12 @@ class Argument(Symbol):
             self.name = name
         super(Argument, self).__init__()
 
+    def __setstate__(self, state):
+        for key, value in state.items():
+            setattr(self, key, value)
+
     def __getstate__(self):
-        state = super(Argument, self).__getstate__()
+        state = super(Argument, self).__getstate__() or {}
         state.update({slot: getattr(self, slot) for slot in self.__slots__
                       if hasattr(self, slot)})
         return state

--- a/symfit/core/models.py
+++ b/symfit/core/models.py
@@ -12,7 +12,7 @@ import sympy
 from sympy.core.relational import Relational
 import numpy as np
 from toposort import toposort
-from scipy.integrate import odeint
+from scipy.integrate import solve_ivp
 
 from .argument import Parameter, Variable
 from .support import (
@@ -988,21 +988,20 @@ class ODEModel(BaseGradientModel):
     Model build from a system of ODEs. When the model is called, the ODE is
     integrated using the LSODA package.
     """
-    def __init__(self, model_dict, initial, *lsoda_args, **lsoda_kwargs):
+    def __init__(self, model_dict, initial, **integrator_kwargs):
         """
         :param model_dict: Dictionary specifying ODEs. e.g.
             model_dict = {D(y, x): a * x**2}
         :param initial: ``dict`` of initial conditions for the ODE.
             Must be provided! e.g.
             initial = {y: 1.0, x: 0.0}
-        :param lsoda_args: args to pass to the lsoda solver.
-            See `scipy's odeint <http://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.odeint.html>`_
+        :param integrator_kwargs: kwargs to pass to the ODE integrator.
+            See `scipy's solve_ivp <https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html>`_
             for more info.
-        :param lsoda_kwargs: kwargs to pass to the lsoda solver.
         """
         self.initial = initial
-        self.lsoda_args = lsoda_args
-        self.lsoda_kwargs = lsoda_kwargs
+        self.integrator_kwargs = {'method': 'LSODA'}
+        self.integrator_kwargs.update(integrator_kwargs)
 
         sort_func = operator.attrgetter('name')
         # Mapping from dependent vars to their derivatives
@@ -1143,8 +1142,8 @@ class ODEModel(BaseGradientModel):
         t_like = bound_arguments.arguments[self.independent_vars[0].name]
 
         # System of functions to be integrated
-        f = lambda ys, t, *a: [c(t, *(list(ys) + list(a))) for c in self._ncomponents]
-        Dfun = lambda ys, t, *a: [[c(t, *(list(ys) + list(a))) for c in row] for row in self._njacobian]
+        f = lambda t, ys, *a: [c(t, *(list(ys) + list(a))) for c in self._ncomponents]
+        Dfun = lambda t, ys, *a: [[c(t, *(list(ys) + list(a))) for c in row] for row in self._njacobian]
 
         initial_dependent = [self.initial[var] for var in self.dependent_vars]
         # For the initial values, substitute any parameter for the value passed
@@ -1182,36 +1181,42 @@ class ODEModel(BaseGradientModel):
         # Call the numerical integrator. Note that we only pass the
         # model_params, which will be used by sympy_to_py to create something we
         # can evaluate numerically.
-        ans_bigger = odeint(
+        # We need to set the right bound to be just a little bit larger so that
+        # we can be sure all time values are within t_span. Minimal complication
+        # is that if you shift the bounds by too little (say,
+        # np.finfo(float).tiny) the LSODA integrator doesn't terminate anymore.
+        ans_bigger = solve_ivp(
             f,
-            initial_dependent,
-            t_bigger,
+            t_span=(t_bigger[0], t_bigger[-1] + 1e-8),
+            y0=initial_dependent,
+            t_eval=t_bigger,
             args=tuple(
                 bound_arguments.arguments[param.name] for param in self.model_params
             ),
-            Dfun=Dfun,
-            *self.lsoda_args, **self.lsoda_kwargs
+            jac=Dfun,
+            **self.integrator_kwargs
         )
-        ans_smaller = odeint(
+        ans_smaller = solve_ivp(
             f,
-            initial_dependent,
-            t_smaller,
+            t_span=(t_smaller[0], t_smaller[-1] - 1e-8),
+            y0=initial_dependent,
+            t_eval=t_smaller,
             args=tuple(
                 bound_arguments.arguments[param.name] for param in self.model_params
             ),
-            Dfun=Dfun,
-            *self.lsoda_args, **self.lsoda_kwargs
+            jac=Dfun,
+            **self.integrator_kwargs
         )
 
-        ans = np.concatenate((ans_smaller[1:][::-1], ans_bigger))
+        ans = np.concatenate((ans_smaller.y[:, :0:-1], ans_bigger.y), axis=1)
         if t_initial in t_like:
             # The user also requested to know the value at t_initial, so keep it.
-            return ans.T
+            return ans
         else:
             # The user didn't ask for the value at t_initial, so exclude it.
             # (t_total contains all the t-points used for the integration,
             # and so is t_like with t_initial inserted at the right position).
-            return ans[t_total != t_initial].T
+            return ans[:, t_total != t_initial]
 
     def __call__(self, *args, **kwargs):
         """

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -144,7 +144,7 @@ def test_param_error_analytical():
     """
     N = 10000
     sigma = 25.0
-    xn = np.arange(N, dtype=np.float)
+    xn = np.arange(N, dtype=float)
     np.random.seed(110)
     yn = np.random.normal(size=xn.shape, scale=sigma)
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -42,23 +42,25 @@ def test_simple_kinetics():
     tdata = np.array([10, 26, 44, 70, 120])
     adata = 10e-4 * np.array([44, 34, 27, 20, 14])
     a, b, t = variables('a, b, t')
-    k, a0 = parameters('k, a0')
+    k, = parameters('k')
     k.value = 0.01
-    # a0.value, a0.min, a0.max = 54 * 10e-4, 40e-4, 60e-4
     a0 = 54 * 10e-4
 
+    # Analytical solution
+    model = GradientModel({a: 1 / (k * t + 1 / a0)})
+    fit = Fit(model, t=tdata, a=adata)
+    fit_result = fit.execute()
+
     model_dict = {
-        D(a, t): - k * a**2,
-        D(b, t): k * a**2,
+        D(a, t): - k * a ** 2,
+        D(b, t): k * a ** 2,
     }
-
     ode_model = ODEModel(model_dict, initial={t: 0.0, a: a0, b: 0.0})
-
     fit = Fit(ode_model, t=tdata, a=adata, b=None)
-    fit_result = fit.execute(tol=1e-9)
+    ode_result = fit.execute()
 
-    assert fit_result.value(k) == pytest.approx(4.302875e-01, 1e-5)
-    assert fit_result.stdev(k) == pytest.approx(6.447068e-03, 1e-5)
+    assert ode_result.value(k) == pytest.approx(fit_result.value(k), 1e-5)
+    assert ode_result.stdev(k) == pytest.approx(fit_result.stdev(k), 1e-5)
 
 
 def test_global_fitting():

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -773,7 +773,7 @@ def test_error_analytical():
     """
     N = 10000
     sigma = 10.0 * np.ones(N)
-    xn = np.arange(N, dtype=np.float)
+    xn = np.arange(N, dtype=float)
     # yn = np.zeros_like(xn)
     np.random.seed(10)
     yn = np.random.normal(size=len(xn), scale=sigma)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -264,7 +264,7 @@ def test_pickle():
         {y: a * x ** b}, connectivity_mapping={y: {x, a, b}}
     )
     # Test if lsoda args and kwargs are pickled too
-    ode_model = ODEModel({D(y, x): a * x + b}, {x: 0.0}, 3, 4, some_kwarg=True)
+    ode_model = ODEModel({D(y, x): a * x + b}, {x: 0.0}, some_kwarg=True)
 
     models = [exact_model, constraint, num_model, ode_model, connected_num_model]
     for model in models:

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -249,7 +249,6 @@ def test_initial_parameters():
     AA, AAB, BAAB = ode_model(t=tdata, k=0.1, l=0.2, m=.3, p=0.3, a0=10, c0=0)
     fit = Fit(ode_model, t=tdata, a=AA, c=AAB, d=BAAB)
     results = fit.execute()
-    print(results)
 
     acceptable_abs_tol = 2.5e-5
     assert results.value(a0) == pytest.approx(10, abs=acceptable_abs_tol)

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -34,7 +34,7 @@ def test_known_solution():
 
     # Generate some data
     tdata = np.linspace(0, 3, 50)
-    ydata = sol(t=tdata, p=3.22)[0]
+    ydata, = sol(t=tdata, p=3.22)
     ydata += np.random.normal(0, 0.005, ydata.shape)
 
     ode_model = ODEModel(model_dict, initial={t: 0.0, y: ydata[0]})

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -33,7 +33,7 @@ def test_known_solution():
     sol = Model({y: exp(- p * t)})
 
     # Generate some data
-    tdata = np.linspace(0, 3, 10001)
+    tdata = np.linspace(0, 3, 50)
     ydata = sol(t=tdata, p=3.22)[0]
     ydata += np.random.normal(0, 0.005, ydata.shape)
 
@@ -89,7 +89,7 @@ def test_polgar():
     ode_model = ODEModel(model_dict, initial={t: 0.0, a: a0, c: 0.0, d: 0.0})
 
     # Generate some data
-    tdata = np.linspace(0, 3, 1000)
+    tdata = np.linspace(0, 3, 50)
     # Eval
     AA, AAB, BAAB = ode_model(t=tdata, k=0.1, l=0.2, m=.3, p=0.3)
 
@@ -244,7 +244,7 @@ def test_initial_parameters():
     ode_model = ODEModel(model_dict, initial={t: 0.0, a: a0, c: c0, d: 0.0})
 
     # Generate some data
-    tdata = np.linspace(0, 3, 1000)
+    tdata = np.linspace(0, 3, 50)
     # Eval
     AA, AAB, BAAB = ode_model(t=tdata, k=0.1, l=0.2, m=.3, p=0.3, a0=10, c0=0)
     fit = Fit(ode_model, t=tdata, a=AA, c=AAB, d=BAAB)

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -230,7 +230,7 @@ def test_initial_parameters():
     Identical to test_polgar, but with a0 as free Parameter.
     """
     a, b, c, d, t = variables('a, b, c, d, t')
-    k, p, l, m = parameters('k, p, l, m')
+    k, p, l, m = parameters('k, p, l, m', min=0)
 
     a0 = Parameter('a0', min=0, value=10, fixed=True)
     c0 = Parameter('c0', min=0, value=0.05)


### PR DESCRIPTION
This PR switches the ODEModel from the old `odeint` to the newer `solve_ivp`. And there was much rejoicing. Also does some minor polishing left and right.