### PR TITLE
test_chained_min: relax test constraints

### DIFF
--- a/tests/test_global_opt.py
+++ b/tests/test_global_opt.py
@@ -82,8 +82,8 @@ class TestGlobalOptGaussian:
         fit_result = fit.execute(
             DifferentialEvolution={'seed': 0, 'tol': 1e-4, 'maxiter': 10}
         )
-        assert fit_result.value(self.x0_1) == pytest.approx(0.4, 1e-4)
-        assert fit_result.value(self.y0_1) == pytest.approx(0.4, 1e-4)
+        assert fit_result.value(self.x0_1) == pytest.approx(0.4, 1e-2)
+        assert fit_result.value(self.y0_1) == pytest.approx(0.4, 1e-2)
         assert curvals == [p.value for p in self.model.params]
 
     def test_chained_min_signature(self):


### PR DESCRIPTION
This test fails on ppc64el otherwise, see e.g. https://ci.debian.net/data/autopkgtest/testing/ppc64el/s/symfit/32008561/log.gz (search for `test_chained_min`).