### PR TITLE
Fix issue #374 (Crash with numpy version 1.15 and above (function np.product removed))

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -51,7 +51,7 @@ class TakesData(object):
         :param named_data: assign dependent, independent and sigma variables data by name.
 
         Standard deviation can be provided to any variable. They have to be prefixed
-        with sigma\_. For example, let x be a Variable. Then sigma_x will give the
+        with sigma_. For example, let x be a Variable. Then sigma_x will give the
         stdev in x.
         """
         if isinstance(model, BaseModel):

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -22,6 +22,14 @@ from .models import BaseModel, Model, BaseNumericalModel, CallableModel
 
 import inspect
 
+numpy_version = np.__version__
+from distutils.version import LooseVersion
+
+if LooseVersion(numpy_version) >= LooseVersion("1.15.0"):
+    numpy_product_function = np.prod
+else:
+    numpy_product_function = np.product
+
 class TakesData(object):
     """
     An base class for everything that takes data. Most importantly, it takes care
@@ -253,7 +261,7 @@ class HasCovarianceMatrix(TakesData):
             # Residual sum of squares
             rss = 2 * objective(**key2str(best_fit_params))
             # Degrees of freedom
-            raw_dof = np.sum([np.product(shape) for shape in self.data_shapes[1]])
+            raw_dof = np.sum([numpy_product_function(shape) for shape in self.data_shapes[1]])
             dof = raw_dof - len(self.model.params)
             if self.absolute_sigma:
                 # When interpreting as measurement error, we do not rescale.

--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -22,10 +22,11 @@ from .models import BaseModel, Model, BaseNumericalModel, CallableModel
 
 import inspect
 
-numpy_version = np.__version__
-from distutils.version import LooseVersion
+from packaging.version import Version
 
-if LooseVersion(numpy_version) >= LooseVersion("1.15.0"):
+numpy_version = Version(np.__version__)
+
+if numpy_version >= Version("1.15.0"):
     numpy_product_function = np.prod
 else:
     numpy_product_function = np.product

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -7,7 +7,19 @@ import pytest
 
 import numpy as np
 import sympy
-from scipy.integrate import simps
+
+from packaging.version import Version
+import pkg_resources
+
+scipy_version = pkg_resources.get_distribution("scipy").version
+
+if Version(scipy_version) >= Version("1.14.0"):
+    from scipy.integrate import simpson
+    scipy_simpson_function = simpson
+else:
+    from scipy.integrate import simps
+    scipy_simpson_function = simps
+
 from scipy.optimize import NonlinearConstraint, minimize
 
 from symfit import (
@@ -763,7 +775,7 @@ def test_constrained_dependent_on_model():
     constraint_model = Model.as_constraint(A - 1, model, constraint_type=Eq)
     constraint_exact = Eq(A, 1)
     constraint_num = CallableNumericalModel.as_constraint(
-        {Y: lambda x, y: simps(y, x) - 1},  # Integrate using simps
+        {Y: lambda x, y: scipy_simpson_function(y, x=x) - 1},  # Integrate using simps
         model=model,
         connectivity_mapping={Y: {x, y}},
         constraint_type=Eq

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -23,6 +23,14 @@ from tests.test_minimizers import subclasses
 
 import inspect
 
+from packaging.version import Version
+
+numpy_version = Version(np.__version__)
+
+if numpy_version >= Version("1.15.0"):
+    numpy_product_function = np.prod
+else:
+    numpy_product_function = np.product
 
 def setup_module():
     np.random.seed(0)
@@ -529,7 +537,7 @@ def test_likelihood_fitting_exponential():
     fit = Fit(pdf, xdata, objective=LogLikelihood)
     fit_result = fit.execute()
     pdf_i = fit.model(x=xdata, **fit_result.params).y  # probabilities
-    likelihood = np.product(pdf_i)
+    likelihood = numpy_product_function(pdf_i)
     loglikelihood = np.sum(np.log(pdf_i))
 
     assert fit_result.value(b) == pytest.approx(mean, 1e-3)


### PR DESCRIPTION
Fixes Issue #374. Based on the numpy version, fit.py decides if np.prod or np.product should be used. 