### PR TITLE
Fix "SyntaxWarning: invalid escape sequence"

### DIFF
--- a/symfit/core/fit.py
+++ b/symfit/core/fit.py
@@ -43,7 +43,7 @@ class TakesData(object):
         :param named_data: assign dependent, independent and sigma variables data by name.
 
         Standard deviation can be provided to any variable. They have to be prefixed
-        with sigma\_. For example, let x be a Variable. Then sigma_x will give the
+        with sigma_. For example, let x be a Variable. Then sigma_x will give the
         stdev in x.
         """
         if isinstance(model, BaseModel):

--- a/symfit/core/fit_results.py
+++ b/symfit/core/fit_results.py
@@ -33,7 +33,7 @@ class FitResults(object):
         :param minimizer: Minimizer instance used.
         :param objective: Objective function which was optimized.
         :param message: Status message returned by the minimizer.
-        :param \**minimizer_output: Raw output as given by the minimizer.
+        :param **minimizer_output: Raw output as given by the minimizer.
         """
         self.constraints = constraints if constraints is not None else []
         self.minimizer_output = minimizer_output

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -212,8 +212,8 @@ class ChainedMinimizer(BaseMinimizer):
         :param minimizers: a :class:`~collections.abc.Sequence` of
             :class:`~symfit.core.minimizers.BaseMinimizer` objects, which need
             to be run in order.
-        :param \*args: passed to :func:`symfit.core.minimizers.BaseMinimizer.__init__`.
-        :param \*\*kwargs: passed to :func:`symfit.core.minimizers.BaseMinimizer.__init__`.
+        :param *args: passed to :func:`symfit.core.minimizers.BaseMinimizer.__init__`.
+        :param **kwargs: passed to :func:`symfit.core.minimizers.BaseMinimizer.__init__`.
         '''
         super(ChainedMinimizer, self).__init__(*args, **kwargs)
         self.minimizers = minimizers
@@ -331,7 +331,7 @@ class ScipyMinimize(object):
             :class:`~symfit.core.minimizers.BoundedMinimizer`.
         :param jacobian: The Jacobian. Usually filled by
             :class:`~symfit.core.minimizers.ScipyGradientMinimize`.
-        :param \*\*minimize_options: Further keywords to pass to
+        :param **minimize_options: Further keywords to pass to
             :func:`scipy.optimize.minimize`. Note that your `method` will
             usually be filled by a specific subclass.
         """
@@ -791,7 +791,7 @@ class MINPACK(ScipyBoundedMinimizer, GradientMinimizer):
 
     def execute(self, jacobian=None, method='trf', **minpack_options):
         """
-        :param \*\*minpack_options: Any named arguments to be passed to
+        :param **minpack_options: Any named arguments to be passed to
             :func:`scipy.optimize.least_squares`
         """
         if jacobian is None:

--- a/symfit/core/objectives.py
+++ b/symfit/core/objectives.py
@@ -393,7 +393,7 @@ class HessianObjectiveJacApprox(HessianObjective):
     upon calculating ``eval_hessian``.
 
     However, if the model does not have a Hessian defined through
-    ``eval_hessian``, we approximate the Hessian as :math:`J^{T}\cdot J`,
+    ``eval_hessian``, we approximate the Hessian as :math:`J^{T}\\cdot J`,
     where :math:`J` is the Jacobian of the model. This approximation is valid
     when, amongst other things, the residuals are sufficiently small. It can
     therefore only be used after fitting, not during.
@@ -402,7 +402,7 @@ class HessianObjectiveJacApprox(HessianObjective):
     shape of the hessian of the model, when ``eval_hessian`` is called. This
     code injection will therefore result in the terms proportional to the
     hessian of the model dropping out, which leaves the famous
-    :math:`J^{T}\cdot J` approximation.
+    :math:`J^{T}\\cdot J` approximation.
     """
     def eval_hessian(self, ordered_parameters=[], **parameters):
         """

--- a/symfit/core/operators.py
+++ b/symfit/core/operators.py
@@ -66,7 +66,7 @@ def call(self, *values, **named_values):
     :param values: Values for the Parameters and Variables of the Expr.
     :param named_values: Values for the vars and params by name. ``named_values`` is
         allowed to contain too many values, as this sometimes happens when using
-        \*\*fit_result.params on a submodel. The irrelevant params are simply ignored.
+        **fit_result.params on a submodel. The irrelevant params are simply ignored.
     :return: The function evaluated at ``values``. The type depends entirely on the input.
         Typically an array or a float but nothing is enforced.
     """

--- a/symfit/core/support.py
+++ b/symfit/core/support.py
@@ -295,9 +295,9 @@ def jacobian(expr, symbols):
 def key2str(target):
     """
     In ``symfit`` there are many dicts with symbol: value pairs.
-    These can not be used immediately as \*\*kwargs, even though this would make
+    These can not be used immediately as **kwargs, even though this would make
     a lot of sense from the context.
-    This function wraps such dict to make them usable as \*\*kwargs immediately.
+    This function wraps such dict to make them usable as **kwargs immediately.
 
     :param target: `Mapping` to be made save
     :return: `Mapping` of str(symbol): value pairs.


### PR DESCRIPTION
I am getting SyntaxWarnings from Pyodide, but other python projects seem to have similar issues, e.g. [this one](https://github.com/python-control/python-control/issues/182) (and a [matching fix](https://github.com/python-control/python-control/pull/187/files)).

At the moment `fit_result.py` escapes first asterisk with a backslash (line 36) but not the second one, so I guess backslashes are indeed unnecessary.


To reproduce open [pyodide console](https://pyodide.org/en/stable/console.html) and enter
```
import micropip; await micropip.install('symfit'); import symfit
```

Observed output:
```
>>> import micropip; await micropip.install('symfit'); import symfit
/lib/python3.12/site-packages/symfit/core/operators.py:48: SyntaxWarning: invalid escape sequence '\*'
  """
/lib/python3.12/site-packages/symfit/core/support.py:296: SyntaxWarning: invalid escape sequence '\*'
  """
/lib/python3.12/site-packages/symfit/core/fit.py:32: SyntaxWarning: invalid escape sequence '\_'
  """
/lib/python3.12/site-packages/symfit/core/minimizers.py:211: SyntaxWarning: invalid escape sequence '\*'
  '''
/lib/python3.12/site-packages/symfit/core/minimizers.py:327: SyntaxWarning: invalid escape sequence '\*'
  """
/lib/python3.12/site-packages/symfit/core/minimizers.py:793: SyntaxWarning: invalid escape sequence '\*'
  """
/lib/python3.12/site-packages/symfit/core/fit_results.py:29: SyntaxWarning: invalid escape sequence '\*'
  """
/lib/python3.12/site-packages/symfit/core/objectives.py:389: SyntaxWarning: invalid escape sequence '\c'
  """

```